### PR TITLE
Fix/cache overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.1] - 2022-04-21
+
+### Fixed
+- Cache overflow bug
+
 ## [v1.2.0] - 2022-04-20
 
 ### Changed

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -350,7 +350,7 @@ var DownloadData = func(nodes []string, path string, start int64, end int64, max
 			return nil, fmt.Errorf("Retrieving data failed for %s: %w", path, err)
 		}
 
-		downloadCache.Set(cacheKey, buf, time.Minute*60)
+		downloadCache.Set(cacheKey, buf, int64(len(buf)), time.Minute*60)
 		logs.Debugf("File %s stored in cache, with coordinates [%d, %d)", path, chStart, chEnd)
 
 		if endofst > int64(len(buf)) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -35,7 +35,7 @@ func (c *mockCache) Get(key string) (interface{}, bool) {
 	return nil, false
 }
 
-func (c *mockCache) Set(key string, value interface{}, ttl time.Duration) bool {
+func (c *mockCache) Set(key string, value interface{}, cost int64, ttl time.Duration) bool {
 	c.key = key
 	c.data = value.([]byte)
 	return true
@@ -589,7 +589,7 @@ func TestDownloadData_FoundCache(t *testing.T) {
 
 	// Save some data to cache
 	expectedData := []byte("hellothere")
-	downloadCache.Set("sdconnect_project_container_object_0", expectedData, time.Minute*1)
+	downloadCache.Set("sdconnect_project_container_object_0", expectedData, int64(len(expectedData)), time.Minute*1)
 
 	// Invoke function
 	data, err := DownloadData(

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -39,7 +39,7 @@ func TestSetAndGet(t *testing.T) {
 	key := "bob"
 	content := "¿why is a raven like a writing desk?"
 
-	ok := c.Set(key, content, -1)
+	ok := c.Set(key, content, int64(len(content)), -1)
 	if !ok {
 		t.Fatal("Saving value failed")
 	}
@@ -68,7 +68,7 @@ func TestSetAndGet_Expired(t *testing.T) {
 	key := "muumi"
 	content := "To infinity and beyond"
 
-	ok := c.Set(key, content, 2*time.Second)
+	ok := c.Set(key, content, int64(len(content)), 2*time.Second)
 	if !ok {
 		t.Fatal("Saving value failed")
 	}
@@ -89,7 +89,7 @@ func TestDel(t *testing.T) {
 		t.Fatal("Cache is nil")
 	}
 
-	c.Set("key", "I am information", -1)
+	c.Set("key", "I am information", int64(len("I am information")), -1)
 	c.Del("key")
 
 	time.Sleep(wait)
@@ -109,9 +109,9 @@ func TestClear(t *testing.T) {
 		t.Fatal("Cache is nil")
 	}
 
-	c.Set("key", "I am information", -1)
-	c.Set("key2", "More information", -1)
-	c.Set("key3", "very secret info", -1)
+	c.Set("key", "I am information", int64(len("I am information")), -1)
+	c.Set("key2", "More information", int64(len("More information")), -1)
+	c.Set("key3", "very secret info", int64(len("very secret info")), -1)
 
 	time.Sleep(wait)
 	c.Clear()


### PR DESCRIPTION
We were storing items into the cache without properly setting the cost of items, we had a constant cost of `1` for items, which would be acceptable if we used a maximum number of items for the cache, but because we use space (bytes) as the maximum size value, the cost must also be given as space taken from the cache. The cost is now given as the size (bytes) of the stored item, so it properly takes up space from the cache and doesn't overflow.