### PR TITLE
Thumbnail generation not an obstacle for refresh

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -275,7 +275,7 @@ func main() {
 	go func() {
 		for {
 			userChooseUpdate(&stdinReader{})
-			if fs.FilesOpen() {
+			if fs.FilesOpen(mount) {
 				logs.Warningf("You have files in use and thus updating is not possible")
 				continue
 			}

--- a/cmd/qt/main.go
+++ b/cmd/qt/main.go
@@ -163,7 +163,7 @@ func (qb *QmlBridge) openFuse() {
 }
 
 func (qb *QmlBridge) refreshFuse() string {
-	if qb.fs.FilesOpen() {
+	if qb.fs.FilesOpen(qb.MountPoint()) {
 		return "You have files in use and thus updating is not possible"
 	}
 	go func() {

--- a/internal/filesystem/enabled.go
+++ b/internal/filesystem/enabled.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -63,6 +64,15 @@ var isValidOpen = func() bool {
 					logs.Debug("Finder trying to create thumbnails")
 					return false
 				}
+			}
+		}
+	case "windows":
+		_, _, pid := fuse.Getcontext()
+		task := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/fo", "table", "/nh")
+		if res, err := task.Output(); err == nil {
+			parts := strings.Fields(string(res))
+			if parts[0] == "explorer.exe" {
+				return false
 			}
 		}
 	}

--- a/internal/filesystem/enabled.go
+++ b/internal/filesystem/enabled.go
@@ -68,7 +68,8 @@ var isValidOpen = func() bool {
 		}
 	case "windows":
 		_, _, pid := fuse.Getcontext()
-		task := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/fo", "table", "/nh")
+		filter := fmt.Sprintf("PID eq %d", pid)
+		task := exec.Command("tasklist", "/FI", filter, "/fo", "table", "/nh")
 		if res, err := task.Output(); err == nil {
 			parts := strings.Fields(string(res))
 			if parts[0] == "explorer.exe" {

--- a/internal/filesystem/enabled.go
+++ b/internal/filesystem/enabled.go
@@ -73,6 +73,7 @@ var isValidOpen = func() bool {
 		if res, err := task.Output(); err == nil {
 			parts := strings.Fields(string(res))
 			if parts[0] == "explorer.exe" {
+				logs.Debug("Explorer trying to create thumbnails")
 				return false
 			}
 		}

--- a/internal/filesystem/enabled_test.go
+++ b/internal/filesystem/enabled_test.go
@@ -26,9 +26,14 @@ func TestOpen(t *testing.T) {
 		{"NOT_FILE", "Rep1/child_1/dir_", nil, -fuse.EISDIR},
 	}
 
+	origIsValidOpen := isValidOpen
 	origUpdateAttributes := api.UpdateAttributes
-	defer func() { api.UpdateAttributes = origUpdateAttributes }()
+	defer func() {
+		isValidOpen = origIsValidOpen
+		api.UpdateAttributes = origUpdateAttributes
+	}()
 
+	isValidOpen = func() bool { return true }
 	api.UpdateAttributes = func(nodes []string, fsPath string, attr interface{}) error {
 		return &api.RequestError{StatusCode: 404}
 	}
@@ -74,8 +79,14 @@ func TestOpen_Decryption_Check(t *testing.T) {
 		},
 	}
 
+	origIsValidOpen := isValidOpen
 	origUpdateAttributes := api.UpdateAttributes
-	defer func() { api.UpdateAttributes = origUpdateAttributes }()
+	defer func() {
+		isValidOpen = origIsValidOpen
+		api.UpdateAttributes = origUpdateAttributes
+	}()
+
+	isValidOpen = func() bool { return true }
 
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
@@ -134,8 +145,14 @@ func TestOpen_Decryption_Check_Error(t *testing.T) {
 		},
 	}
 
+	origIsValidOpen := isValidOpen
 	origUpdateAttributes := api.UpdateAttributes
-	defer func() { api.UpdateAttributes = origUpdateAttributes }()
+	defer func() {
+		isValidOpen = origIsValidOpen
+		api.UpdateAttributes = origUpdateAttributes
+	}()
+
+	isValidOpen = func() bool { return true }
 
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {


### PR DESCRIPTION
Previously fuse couldn't be updated when finder/file browser/explorer were generating thumbnails for files. Now for macOS and Windows these open/read calls are cancelled. For Linux, thumbnails are generated but updating is now possible.