### PR TITLE
Add option to read airlock password from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+
+### Added
+- Option to input airlock password from environment variable
+
 ## [v1.3.0] - 2022-11-18
 
 ### Changed

--- a/cmd/airlock/main.go
+++ b/cmd/airlock/main.go
@@ -77,12 +77,18 @@ func main() {
 		logs.Fatal(err)
 	}
 
-	fmt.Println("Enter Password: ")
-	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		logs.Fatalf("Could not read password: %s", err.Error())
+	password, password_from_env := os.LookupEnv("AIRLOCK_PASSWORD")
+
+	if password_from_env {
+		logs.Info("Using password from environment variable AIRLOCK_PASSWORD")
+	} else {
+		fmt.Println("Enter Password: ")
+		bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			logs.Fatalf("Could not read password: %s", err.Error())
+		}
+		password = string(bytePassword)
 	}
-	password := string(bytePassword)
 
 	api.SetBasicToken(username, password)
 

--- a/cmd/airlock/main.go
+++ b/cmd/airlock/main.go
@@ -14,6 +14,8 @@ import (
 )
 
 func usage(self_path string) {
+	fmt.Println("Password is read from environment variable AIRLOCK_PASSWORD")
+	fmt.Println("If this variable is empty airlock requests the password interactively")
 	fmt.Println("Usage:")
 	fmt.Println(" ", self_path, "[-segment-size=size_in_mb] "+
 		"[-journal-number=journal_number] [-original-file=unecrypted_filename] "+


### PR DESCRIPTION
 - Airlock password is read from AIRLOCK_PASSWORD env
 - If env is not set, user is prompted to input their password

Signed-off-by: Valtteri Valtia <vvaltia@csc.fi>