### PR TITLE
Refactor/stricter golang lint

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,5 +39,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3.3.1
         with:
           version: v1.50
-          args: -E gosec,goconst,nestif,bodyclose,rowserrcheck --skip-files cmd/qt/moc.go  --timeout=10m
+          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107 --skip-files cmd/qt/moc.go,cmd/qt/main.go,cmd/qt/logmodel.go,cmd/qt/projectmodel.go  --timeout=10m
           skip-pkg-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `crypt4gh` function `NewCrypt4GHWriterWithoutPrivateKey` now uses list of public keys
+- refactor packages to introduce more restictive linting (consistent camelCase vars, use of `switch`, fix formatting issues)
 
 ### Added
 - Option to input airlock password from environment variable

--- a/cmd/airlock/main.go
+++ b/cmd/airlock/main.go
@@ -13,27 +13,25 @@ import (
 	"golang.org/x/term"
 )
 
-func usage(self_path string) {
-	fmt.Println("Password is read from environment variable AIRLOCK_PASSWORD")
-	fmt.Println("If this variable is empty airlock requests the password interactively")
+func usage(selfPath string) {
 	fmt.Println("Usage:")
-	fmt.Println(" ", self_path, "[-segment-size=size_in_mb] "+
-		"[-journal-number=journal_number] [-original-file=unecrypted_filename] "+
+	fmt.Println(" ", selfPath, "[-segment-size=sizeInMb] "+
+		"[-journal-number=journalNumber] [-original-file=unecryptedFilename] "+
 		"[-quiet] "+"username container filename")
 	fmt.Println("Examples:")
-	fmt.Println(" ", self_path, "testuser testcontainer path/to/file")
-	fmt.Println(" ", self_path, "-segment-size=100 testuser testcontainer path/to/file")
-	fmt.Println(" ", self_path, "-segment-size=100 "+
+	fmt.Println(" ", selfPath, "testuser testcontainer path/to/file")
+	fmt.Println(" ", selfPath, "-segment-size=100 testuser testcontainer path/to/file")
+	fmt.Println(" ", selfPath, "-segment-size=100 "+
 		"-original-file=/path/to/original/unecrypted/file -journal-number=example124"+
 		"testuser testcontainer path/to/file")
 }
 
 func main() {
-	segment_size_mb := flag.Int("segment-size", 4000,
+	segmentSizeMb := flag.Int("segment-size", 4000,
 		"Maximum size of segments in Mb used to upload data. Valid range is 10-4000.")
-	journal_number := flag.String("journal-number", "",
+	journalNumber := flag.String("journal-number", "",
 		"Journal Number/Name specific for Findata uploads")
-	original_filename := flag.String("original-file", "",
+	originalFilename := flag.String("original-file", "",
 		"Filename of original unecrypted file when uploading pre-encrypted file from Findata vm")
 	quiet := flag.Bool("quiet", false, "Print only errors")
 	debug := flag.Bool("debug", false, "Enable debug prints")
@@ -49,7 +47,7 @@ func main() {
 	container := flag.Arg(1)
 	filename := flag.Arg(2)
 
-	if *segment_size_mb < 10 || *segment_size_mb > 4000 {
+	if *segmentSizeMb < 10 || *segmentSizeMb > 4000 {
 		logs.Fatal("Valid values for segment size are 10-4000")
 	}
 
@@ -79,9 +77,9 @@ func main() {
 		logs.Fatal(err)
 	}
 
-	password, password_from_env := os.LookupEnv("AIRLOCK_PASSWORD")
+	password, passwordFromEnv := os.LookupEnv("AIRLOCK_PASSWORD")
 
-	if password_from_env {
+	if passwordFromEnv {
 		logs.Info("Using password from environment variable AIRLOCK_PASSWORD")
 	} else {
 		fmt.Println("Enter Password: ")
@@ -98,11 +96,11 @@ func main() {
 	if encrypted, err = airlock.CheckEncryption(filename); err != nil {
 		logs.Fatal(err)
 	} else if !encrypted {
-		*original_filename = filename
+		*originalFilename = filename
 		filename += ".c4gh"
 	}
 
-	err = airlock.Upload(*original_filename, filename, container, *journal_number, uint64(*segment_size_mb), !encrypted)
+	err = airlock.Upload(*originalFilename, filename, container, *journalNumber, uint64(*segmentSizeMb), !encrypted)
 	if err != nil {
 		logs.Fatal(err)
 	}

--- a/cmd/airlock/main.go
+++ b/cmd/airlock/main.go
@@ -99,7 +99,7 @@ func main() {
 		logs.Fatal(err)
 	} else if !encrypted {
 		*original_filename = filename
-		filename = filename + ".c4gh"
+		filename += ".c4gh"
 	}
 
 	err = airlock.Upload(*original_filename, filename, container, *journal_number, uint64(*segment_size_mb), !encrypted)

--- a/cmd/fuse/main.go
+++ b/cmd/fuse/main.go
@@ -37,6 +37,7 @@ type stdinReader struct {
 
 func (r *stdinReader) readPassword() (string, error) {
 	pwd, err := term.ReadPassword(int(syscall.Stdin))
+
 	return string(pwd), err
 }
 
@@ -46,6 +47,7 @@ func (r *stdinReader) getStream() io.Reader {
 
 func (r *stdinReader) getState() (err error) {
 	r.originalState, err = term.GetState(int(syscall.Stdin))
+
 	return
 }
 
@@ -76,7 +78,7 @@ var askForLogin = func(lr loginReader) (string, string, error) {
 		fmt.Printf("Log in with your CSC credentials\n")
 		fmt.Print("Enter username: ")
 		scanner := bufio.NewScanner(lr.getStream())
-		
+
 		if scanner.Scan() {
 			username = scanner.Text()
 		}
@@ -104,6 +106,7 @@ func checkEnvVars() (string, string, bool) {
 	if username_env && password_env {
 		return username, password, true
 	}
+
 	return "", "", false
 }
 
@@ -140,6 +143,7 @@ var login = func(lr loginReader) error {
 		}
 		if success {
 			logs.Error(err) // If SD Submit authorization fails
+
 			return nil
 		}
 
@@ -166,6 +170,7 @@ func processFlags() error {
 	mount = filepath.Clean(mount)
 	api.SetRequestTimeout(requestTimeout)
 	logs.SetLevel(logLevel)
+
 	return nil
 }
 
@@ -184,6 +189,7 @@ func shutdown() <-chan bool {
 		logs.Info("Shutting down Data Gateway")
 		done <- true
 	}()
+
 	return done
 }
 
@@ -227,6 +233,7 @@ func main() {
 			userChooseUpdate(os.Stdin)
 			if fs.FilesOpen(mount) {
 				logs.Warningf("You have files in use and thus updating is not possible")
+
 				continue
 			}
 			newFs := filesystem.InitializeFileSystem(nil)

--- a/cmd/fuse/main.go
+++ b/cmd/fuse/main.go
@@ -100,10 +100,10 @@ var askForLogin = func(lr loginReader) (string, string, error) {
 }
 
 func checkEnvVars() (string, string, bool) {
-	username, username_env := os.LookupEnv("CSC_USERNAME")
-	password, password_env := os.LookupEnv("CSC_PASSWORD")
+	username, usernameEnv := os.LookupEnv("CSC_USERNAME")
+	password, passwordEnv := os.LookupEnv("CSC_PASSWORD")
 
-	if username_env && password_env {
+	if usernameEnv && passwordEnv {
 		return username, password, true
 	}
 

--- a/cmd/fuse/main_test.go
+++ b/cmd/fuse/main_test.go
@@ -56,12 +56,14 @@ func (s *testStream) Read(p []byte) (int, error) {
 	}
 	if s.done || s.idx == len(s.data) {
 		s.done = false
+
 		return 0, io.EOF
 	}
 	content := []byte(s.data[s.idx])
 	copy(p, content)
 	s.done = true
 	s.idx++
+
 	return len(content), nil
 }
 
@@ -189,6 +191,7 @@ func TestLogin(t *testing.T) {
 					return "", "", fmt.Errorf("Function did not approve login during first loop")
 				}
 				count++
+
 				return "dumbledore", "345fgj78", nil
 			},
 			func(uname, pwd string) (bool, error) {
@@ -199,6 +202,7 @@ func TestLogin(t *testing.T) {
 				if pwd != password {
 					return false, fmt.Errorf("Incorrect password. Expected=%s, received=%s", password, pwd)
 				}
+
 				return true, nil
 			},
 		},
@@ -209,6 +213,7 @@ func TestLogin(t *testing.T) {
 					return "", "", fmt.Errorf("Function did not approve login during first loop")
 				}
 				count++
+
 				return "sandman", "89bf5cifu6vo", nil
 			},
 			func(uname, pwd string) (bool, error) {
@@ -219,6 +224,7 @@ func TestLogin(t *testing.T) {
 				if pwd != password {
 					return false, fmt.Errorf("Incorrect password. Expected=%s, received=%s", password, pwd)
 				}
+
 				return true, errExpected
 			},
 		},
@@ -230,12 +236,14 @@ func TestLogin(t *testing.T) {
 					return "", "", fmt.Errorf("Function in infinite loop")
 				}
 				count++
+
 				return usernames[count-1], passwords[count-1], nil
 			},
 			func(uname, pwd string) (bool, error) {
 				if uname == "Doris" && pwd == "pwd" {
 					return true, nil
 				}
+
 				return false, &api.RequestError{StatusCode: 401}
 			},
 		},
@@ -265,6 +273,7 @@ func TestLogin(t *testing.T) {
 					return "", "", fmt.Errorf("Function in infinite loop")
 				}
 				count++
+
 				return "", "", nil
 			},
 			func(uname, pwd string) (bool, error) {
@@ -344,6 +353,7 @@ func TestProcessFlags(t *testing.T) {
 	}
 	mountpoint.CheckMountPoint = func(mount string) error {
 		testMount = mount
+
 		return nil
 	}
 	api.SetRequestTimeout = func(timeout int) {

--- a/cmd/fuse/main_test.go
+++ b/cmd/fuse/main_test.go
@@ -158,19 +158,21 @@ func TestAskForLogin(t *testing.T) {
 			os.Stdout = sout
 			null.Close()
 
-			if tt.testname != "OK" {
+			switch {
+			case tt.testname != "OK":
 				if err == nil {
 					t.Error("Function should have returned error")
 				} else if err.Error() != tt.errorText {
 					t.Errorf("Function returned incorrect error\nExpected=%s\nReceived=%s", tt.errorText, err.Error())
 				}
-			} else if err != nil {
+			case err != nil:
 				t.Errorf("Function returned error: %s", err.Error())
-			} else if str1 != tt.username {
+			case str1 != tt.username:
 				t.Errorf("Username incorrect. Expected=%s, received=%s", tt.username, str1)
-			} else if str2 != tt.password {
+			case str2 != tt.password:
 				t.Errorf("Password incorrect. Expected=%s, received=%s", tt.password, str2)
 			}
+
 		})
 	}
 }
@@ -307,15 +309,17 @@ func TestLogin(t *testing.T) {
 			os.Stdout = sout
 			null.Close()
 
-			if tt.errorText == "" {
+			switch {
+			case tt.errorText == "":
 				if err != nil {
 					t.Errorf("Returned unexpected error: %s", err.Error())
 				}
-			} else if err == nil {
+			case err == nil:
 				t.Error("Function should have returned error")
-			} else if err.Error() != tt.errorText {
+			case err.Error() != tt.errorText:
 				t.Errorf("Function returned incorrect error\nExpected=%s\nReceived=%s", tt.errorText, err.Error())
 			}
+
 		})
 	}
 }
@@ -374,17 +378,19 @@ func TestProcessFlags(t *testing.T) {
 
 			err := processFlags()
 
-			if err != nil {
+			switch {
+			case err != nil:
 				t.Errorf("Returned unexpected error: %s", err.Error())
-			} else if tt.timeout != testTimeout {
+			case tt.timeout != testTimeout:
 				t.Errorf("SetRequestTimeout() received incorrect timeout. Expected=%d, received=%d", tt.timeout, testTimeout)
-			} else if tt.logLevel != testLevel {
+			case tt.logLevel != testLevel:
 				t.Errorf("SetLevel() received incorrect log level. Expected=%s, received=%s", tt.logLevel, testLevel)
-			} else if tt.mount == "" && mount != defaultMount {
+			case tt.mount == "" && mount != defaultMount:
 				t.Errorf("Expected default mount point %s, received=%s", defaultMount, mount)
-			} else if tt.mount != testMount {
+			case tt.mount != testMount:
 				t.Errorf("CheckMountPoint() received incorrect mount point. Expected=%s, received=%s", tt.mount, testMount)
 			}
+
 		})
 	}
 }

--- a/cmd/fuse/main_test.go
+++ b/cmd/fuse/main_test.go
@@ -100,8 +100,8 @@ func TestUserChooseUpdate_Error(t *testing.T) {
 	finished := false
 	buf := &testStream{err: errExpected}
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	logs.SetSignal(func(i int, s []string) {
 		level, strs = i, s
 	})

--- a/internal/airlock/airlock.go
+++ b/internal/airlock/airlock.go
@@ -68,12 +68,14 @@ var IsProjectManager = func() (bool, error) {
 	endpoint, ok := data["userinfo_endpoint"]
 	if !ok {
 		err = errors.New("Config file did not contain key 'userinfo_endpoint'")
+
 		return false, fmt.Errorf("Could not determine endpoint for user info: %w", err)
 	}
 
 	pr, ok := data["login_aud"]
 	if !ok {
 		err = errors.New("Config file did not contain key 'login_aud'")
+
 		return false, fmt.Errorf("Could not determine to which project this Desktop belongs: %w", err)
 	}
 
@@ -93,9 +95,11 @@ var IsProjectManager = func() (bool, error) {
 		for i := range projects {
 			if projects[i] == fmt.Sprintf("%v", pr) {
 				ai.project = fmt.Sprintf("project_%v", pr)
+
 				return true, nil
 			}
 		}
+
 		return false, nil
 	}
 }
@@ -140,6 +144,7 @@ func GetPublicKey() error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", errStr, err)
 	}
+
 	return nil
 }
 
@@ -251,12 +256,14 @@ func Upload(original_filename, filename, container, journal_number string, segme
 	if err = <-errc; err != nil {
 		return fmt.Errorf("Streaming file failed: %w", err)
 	}
+
 	return nil
 }
 
 func reorderNames(filename, directory string) (string, string) {
 	before, after, _ := strings.Cut(strings.TrimRight(directory, "/"), "/")
 	object := strings.TrimLeft(after+"/"+filepath.Base(filename), "/")
+
 	return object, before
 }
 
@@ -269,6 +276,7 @@ var CheckEncryption = func(filename string) (bool, error) {
 	defer file.Close()
 
 	_, err = headers.ReadHeader(file)
+
 	return err == nil, nil
 }
 
@@ -293,12 +301,14 @@ var getFileDetails = func(filename string) (*os.File, string, int64, error) {
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return nil, "", 0, err
 	}
+
 	return file, checksum, file_size, nil
 }
 
 var newCrypt4GHWriter = func(w io.Writer) (io.WriteCloser, error) {
 	pubkeyList := [][chacha20poly1305.KeySize]byte{}
 	pubkeyList = append(pubkeyList, ai.publicKey)
+
 	return streaming.NewCrypt4GHWriterWithoutPrivateKey(w, pubkeyList, nil)
 }
 
@@ -307,10 +317,12 @@ var encrypt = func(file *os.File, pw *io.PipeWriter, errc chan error) {
 	c4gh_writer, err := newCrypt4GHWriter(pw)
 	if err != nil {
 		errc <- err
+
 		return
 	}
 	if _, err = io.Copy(c4gh_writer, file); err != nil {
 		errc <- err
+
 		return
 	}
 	errc <- c4gh_writer.Close()
@@ -352,6 +364,7 @@ var getFileDetailsEncrypt = func(filename string) (rc *readCloser, checksum stri
 	go encrypt(file, pw, errc)
 
 	rc = &readCloser{pr, file, errc}
+
 	return
 }
 
@@ -376,7 +389,9 @@ var put = func(url, manifest string, segment_nro, segment_total int,
 		if errors.As(err, &re) && string(bodyBytes) != "" {
 			return errors.New(string(bodyBytes))
 		}
+
 		return err
 	}
+
 	return nil
 }

--- a/internal/airlock/airlock.go
+++ b/internal/airlock/airlock.go
@@ -79,25 +79,27 @@ var IsProjectManager = func() (bool, error) {
 		var re *api.RequestError
 		if errors.As(err, &re) && re.StatusCode == 400 {
 			return false, fmt.Errorf("Invalid token")
-		} else {
-			return false, err
 		}
+
+		return false, err
+
 	}
 
-	if projectPI, ok := data["projectPI"]; !ok {
+	projectPI, ok := data["projectPI"]
+	if !ok {
 		return false, fmt.Errorf("Response body did not contain key 'projectPI'")
-	} else {
-		projects := strings.Split(fmt.Sprintf("%v", projectPI), " ")
-		for i := range projects {
-			if projects[i] == fmt.Sprintf("%v", pr) {
-				ai.project = fmt.Sprintf("project_%v", pr)
-
-				return true, nil
-			}
-		}
-
-		return false, nil
 	}
+	projects := strings.Split(fmt.Sprintf("%v", projectPI), " ")
+	for i := range projects {
+		if projects[i] == fmt.Sprintf("%v", pr) {
+			ai.project = fmt.Sprintf("project_%v", pr)
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+
 }
 
 // GetPublicKey retrieves the public key from the proxy URL and checks its validity

--- a/internal/airlock/airlock.go
+++ b/internal/airlock/airlock.go
@@ -154,7 +154,7 @@ func Upload(original_filename, filename, container, journal_number string, segme
 	var encrypted_file io.ReadCloser
 	var encrypted_checksum string
 	var encrypted_file_size int64
-	var errc chan error = nil
+	var errc chan error
 	var print_filename = original_filename
 
 	if encrypt {
@@ -242,7 +242,7 @@ func Upload(original_filename, filename, container, journal_number string, segme
 		logs.Info("Uploading manifest file for object " + object + " to container " +
 			container)
 
-		var empty *os.File = nil
+		var empty *os.File
 		err = put(url, container+"/"+upload_dir, -1, -1, empty, query)
 		if err != nil {
 			return fmt.Errorf("Uploading manifest file failed: %w", err)

--- a/internal/airlock/airlock.go
+++ b/internal/airlock/airlock.go
@@ -46,10 +46,6 @@ var GetProjectName = func() string {
 	return ai.project
 }
 
-var currentTime = func() time.Time {
-	return time.Now()
-}
-
 // IsProjectManager uses file '/etc/pam_userinfo/config.json' and SDS AAI to determine if the user is the
 // project manager of the SD Connect project in the current VM
 var IsProjectManager = func() (bool, error) {
@@ -191,7 +187,7 @@ func Upload(original_filename, filename, container, journal_number string, segme
 	query := map[string]string{
 		"filename":  object,
 		"bucket":    container,
-		"timestamp": currentTime().Format(time.RFC3339),
+		"timestamp": time.Now().Format(time.RFC3339),
 	}
 
 	if original_filename != "" {

--- a/internal/airlock/airlock_test.go
+++ b/internal/airlock/airlock_test.go
@@ -522,11 +522,13 @@ func TestUpload_Error(t *testing.T) {
 			}
 
 			errStr := tt.errStr + errExpected.Error()
-			if err := Upload("", "../../test/sample.txt.enc", "bucket684", "", 100, false); err == nil {
+			err := Upload("", "../../test/sample.txt.enc", "bucket684", "", 100, false)
+			switch {
+			case err == nil:
 				t.Error("Function did not return error")
-			} else if err.Error() != errStr {
+			case err.Error() != errStr:
 				t.Errorf("Function returned incorrect error\nExpected=%s\nReceived=%s", errStr, err.Error())
-			} else if file != nil {
+			case file != nil:
 				if err = file.Close(); err == nil {
 					t.Error("File was not closed")
 				}

--- a/internal/airlock/airlock_test.go
+++ b/internal/airlock/airlock_test.go
@@ -155,6 +155,7 @@ func TestIsProjectManager(t *testing.T) {
 				switch v := ret.(type) {
 				case *map[string]any:
 					(*v)["projectPI"] = tt.data
+
 					return nil
 				default:
 					return fmt.Errorf("ret has incorrect type %v, expected *map[string]any", reflect.TypeOf(v))
@@ -253,6 +254,7 @@ func TestPublicKey_Invalid_Key(t *testing.T) {
 		switch v := ret.(type) {
 		case *[]byte:
 			(*v) = []byte(keyStr)
+
 			return nil
 		default:
 			return fmt.Errorf("ret has incorrect type %v, expected *byte[]", reflect.TypeOf(v))
@@ -302,6 +304,7 @@ func TestPublicKey(t *testing.T) {
 		switch v := ret.(type) {
 		case *[]byte:
 			(*v) = []byte(keyStr)
+
 			return nil
 		default:
 			return fmt.Errorf("ret has incorrect type %v, expected *byte[]", reflect.TypeOf(v))
@@ -343,12 +346,14 @@ func TestUpload_FileDetails_Error(t *testing.T) {
 				if filename == tt.failOnFile {
 					return nil, "", 0, errExpected
 				}
+
 				return nil, "", 0, nil
 			}
 			getFileDetailsEncrypt = func(filename string) (*readCloser, string, int64, error) {
 				if filename == tt.failOnFile {
 					return nil, "", 0, errExpected
 				}
+
 				return nil, "", 0, nil
 			}
 
@@ -412,6 +417,7 @@ func TestUpload(t *testing.T) {
 				if err != nil {
 					return nil, "", 0, err
 				}
+
 				return file1, tt.checksum + strings.Repeat("78", i+1), tt.size + 200*int64(i+1), nil
 			}
 			getFileDetailsEncrypt = func(filename string) (*readCloser, string, int64, error) {
@@ -423,6 +429,7 @@ func TestUpload(t *testing.T) {
 				if err != nil {
 					return nil, "", 0, err
 				}
+
 				return &readCloser{file2, file2, nil}, tt.checksum + strings.Repeat("50", i+1), tt.size + 500*int64(i+1), nil
 			}
 
@@ -452,6 +459,7 @@ func TestUpload(t *testing.T) {
 				if !reflect.DeepEqual(query, tt.query) {
 					t.Errorf("Function received incorrect query\nExpected=%v\nReceived=%v", tt.query, query)
 				}
+
 				return nil
 			}
 
@@ -501,6 +509,7 @@ func TestUpload_Error(t *testing.T) {
 				if err != nil {
 					return nil, "", 0, err
 				}
+
 				return file, "", int64(tt.size), nil
 			}
 			getFileDetailsEncrypt = func(filename string) (*readCloser, string, int64, error) {
@@ -513,6 +522,7 @@ func TestUpload_Error(t *testing.T) {
 					return errExpected
 				}
 				count++
+
 				return nil
 			}
 
@@ -575,6 +585,7 @@ func TestUpload_FileContent(t *testing.T) {
 				if err != nil {
 					return nil, "", 0, err
 				}
+
 				return file, "", int64(len(tt.content)), nil
 			}
 
@@ -585,6 +596,7 @@ func TestUpload_FileContent(t *testing.T) {
 						return err
 					}
 				}
+
 				return nil
 			}
 
@@ -614,6 +626,7 @@ func TestUpload_Channel_Error(t *testing.T) {
 		}
 		errc := make(chan error, 1)
 		errc <- errExpected
+
 		return &readCloser{file, file, errc}, "", 0, nil
 	}
 	getFileDetails = func(filename string) (*os.File, string, int64, error) {
@@ -621,6 +634,7 @@ func TestUpload_Channel_Error(t *testing.T) {
 		if err != nil {
 			return nil, "", 0, err
 		}
+
 		return file, "", 0, nil
 	}
 	put = func(url, manifest string, segment_nro, segment_total int, upload_data io.Reader, query map[string]string) error {
@@ -729,6 +743,7 @@ type mockWriteCloser struct {
 
 func (wc *mockWriteCloser) Write(data []byte) (n int, err error) {
 	wc.data = data
+
 	return len(data), wc.writeErr
 }
 
@@ -954,6 +969,7 @@ func TestPut(t *testing.T) {
 				if !reflect.DeepEqual(headers, tt.headers) {
 					t.Errorf("Function received incorrect headers\nExpected=%q\nReceived=%q", tt.headers, headers)
 				}
+
 				return nil
 			}
 
@@ -992,6 +1008,7 @@ func TestPut_Error(t *testing.T) {
 				switch v := ret.(type) {
 				case *[]byte:
 					(*v) = []byte("request body error")
+
 					return tt.err
 				default:
 					return fmt.Errorf("ret has incorrect type %v, expected *byte[]", reflect.TypeOf(v))

--- a/internal/airlock/airlock_test.go
+++ b/internal/airlock/airlock_test.go
@@ -410,7 +410,7 @@ func TestUpload(t *testing.T) {
 			currentTime = func() time.Time {
 				return testTime
 			}
-			var file1, file2 *os.File = nil, nil
+			var file1, file2 *os.File
 			getFileDetails = func(filename string) (*os.File, string, int64, error) {
 				var err error
 				file1, err = os.Open(filename)
@@ -502,7 +502,7 @@ func TestUpload_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
-			var file *os.File = nil
+			var file *os.File
 			getFileDetails = func(filename string) (*os.File, string, int64, error) {
 				var err error
 				file, err = os.Open(filename)

--- a/internal/airlock/airlock_test.go
+++ b/internal/airlock/airlock_test.go
@@ -396,20 +396,15 @@ func TestUpload(t *testing.T) {
 	origGetFileDetails := getFileDetails
 	origGetFileDetailsEncrypt := getFileDetailsEncrypt
 	origPut := put
-	origCurrentTime := currentTime
 	defer func() {
 		getFileDetails = origGetFileDetails
 		getFileDetailsEncrypt = origGetFileDetailsEncrypt
 		put = origPut
-		currentTime = origCurrentTime
 	}()
 
 	for i, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
 			testTime := time.Now()
-			currentTime = func() time.Time {
-				return testTime
-			}
 			var file1, file2 *os.File
 			getFileDetails = func(filename string) (*os.File, string, int64, error) {
 				var err error

--- a/internal/airlock/airlock_test.go
+++ b/internal/airlock/airlock_test.go
@@ -275,7 +275,7 @@ func TestPublicKey_Invalid_Key(t *testing.T) {
 
 func TestPublicKey(t *testing.T) {
 	var tests = []struct {
-		testname, key, decoded_key string
+		testname, key, decodedKey string
 	}{
 		{
 			"OK_1",
@@ -316,8 +316,8 @@ func TestPublicKey(t *testing.T) {
 			keyStr = tt.key
 			if err := GetPublicKey(); err != nil {
 				t.Errorf("Function returned unexpected error: %s", err.Error())
-			} else if tt.decoded_key != string(ai.publicKey[:]) {
-				t.Errorf("Function saved incorrect public key\nExpected=%s\nReceived=%s", tt.decoded_key, ai.publicKey)
+			} else if tt.decodedKey != string(ai.publicKey[:]) {
+				t.Errorf("Function saved incorrect public key\nExpected=%s\nReceived=%s", tt.decodedKey, ai.publicKey)
 			}
 		})
 	}
@@ -370,7 +370,7 @@ func TestUpload_FileDetails_Error(t *testing.T) {
 func TestUpload(t *testing.T) {
 	var tests = []struct {
 		testname, checksum, container, manifest string
-		journal_number, origFile, file          string
+		journalNumber, origFile, file           string
 		size, total                             int64
 		encrypt                                 bool
 		query                                   map[string]string
@@ -430,15 +430,15 @@ func TestUpload(t *testing.T) {
 
 			count := 1
 			total := int(tt.total)
-			put = func(url, manifest string, segment_nro, segment_total int, upload_data io.Reader, query map[string]string) error {
+			put = func(url, manifest string, segmentNro, segment_total int, upload_data io.Reader, query map[string]string) error {
 				if manifest != tt.manifest {
 					t.Errorf("Function received incorrect manifest. Expected=%s, received=%s", tt.manifest, manifest)
 				}
-				if (segment_nro == -1 || segment_total == -1) && tt.total == 1 {
+				if (segmentNro == -1 || segment_total == -1) && tt.total == 1 {
 					t.Error("Segment number and segment total should not be -1")
 				}
-				if segment_nro != count {
-					t.Errorf("Function received incorrect segment number. Expected=%d, received=%d", count, segment_nro)
+				if segmentNro != count {
+					t.Errorf("Function received incorrect segment number. Expected=%d, received=%d", count, segmentNro)
 				}
 				if segment_total != total {
 					t.Errorf("Function received incorrect segment total. Expected=%d, received=%d", total, segment_total)
@@ -458,7 +458,7 @@ func TestUpload(t *testing.T) {
 				return nil
 			}
 
-			if err := Upload(tt.origFile, tt.file, tt.container, tt.journal_number, 100, tt.encrypt); err != nil {
+			if err := Upload(tt.origFile, tt.file, tt.container, tt.journalNumber, 100, tt.encrypt); err != nil {
 				t.Errorf("Function returned unexpected error: %s", err.Error())
 			} else {
 				if file1 != nil {
@@ -512,7 +512,7 @@ func TestUpload_Error(t *testing.T) {
 			}
 
 			count := 1
-			put = func(url, manifest string, segment_nro, segment_total int, upload_data io.Reader, query map[string]string) error {
+			put = func(url, manifest string, segmentNro, segment_total int, upload_data io.Reader, query map[string]string) error {
 				if count == tt.count {
 					return errExpected
 				}
@@ -587,8 +587,8 @@ func TestUpload_FileContent(t *testing.T) {
 			}
 
 			buf := &bytes.Buffer{}
-			put = func(url, manifest string, segment_nro, segment_total int, upload_data io.Reader, query map[string]string) error {
-				if segment_nro != -1 {
+			put = func(url, manifest string, segmentNro, segment_total int, upload_data io.Reader, query map[string]string) error {
+				if segmentNro != -1 {
 					if _, err := buf.ReadFrom(upload_data); err != nil {
 						return err
 					}
@@ -634,7 +634,7 @@ func TestUpload_Channel_Error(t *testing.T) {
 
 		return file, "", 0, nil
 	}
-	put = func(url, manifest string, segment_nro, segment_total int, upload_data io.Reader, query map[string]string) error {
+	put = func(url, manifest string, segmentNro, segment_total int, upload_data io.Reader, query map[string]string) error {
 		return nil
 	}
 
@@ -949,7 +949,7 @@ func TestPut(t *testing.T) {
 		api.MakeRequest = origMakeRequest
 	}()
 
-	testUrl := "https://example.com"
+	testURL := "https://example.com"
 
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
@@ -957,8 +957,8 @@ func TestPut(t *testing.T) {
 				return tt.token
 			}
 			api.MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
-				if url != testUrl {
-					t.Errorf("Function received incorrect url\nExpected=%s\nReceived=%s", testUrl, url)
+				if url != testURL {
+					t.Errorf("Function received incorrect url\nExpected=%s\nReceived=%s", testURL, url)
 				}
 				if !reflect.DeepEqual(query, tt.query) {
 					t.Errorf("Function received incorrect query\nExpected=%q\nReceived=%q", tt.query, query)
@@ -970,7 +970,7 @@ func TestPut(t *testing.T) {
 				return nil
 			}
 
-			err := put(testUrl, "bucket/dir", tt.segNro, tt.segTotal, nil, tt.query)
+			err := put(testURL, "bucket/dir", tt.segNro, tt.segTotal, nil, tt.query)
 			if err != nil {
 				t.Errorf("Function returned error: %s", err.Error())
 			}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -305,27 +305,27 @@ var MakeRequest = func(url string, query, headers map[string]string, body io.Rea
 	// Parse request
 	switch v := ret.(type) {
 	case *SpecialHeaders:
-		(*v).Decrypted = (response.Header.Get("X-Decrypted") == "True")
+		v.Decrypted = (response.Header.Get("X-Decrypted") == "True")
 
-		if (*v).Decrypted {
+		if v.Decrypted {
 			if headerSize := response.Header.Get("X-Header-Size"); headerSize != "" {
-				if (*v).HeaderSize, err = strconv.ParseInt(headerSize, 10, 0); err != nil {
+				if v.HeaderSize, err = strconv.ParseInt(headerSize, 10, 0); err != nil {
 					logs.Warningf("Could not convert header X-Header-Size to integer: %w", err)
-					(*v).Decrypted = false
+					v.Decrypted = false
 				}
 			} else {
 				logs.Warningf("Could not find header X-Header-Size in response")
-				(*v).Decrypted = false
+				v.Decrypted = false
 			}
 		}
 
 		if segSize := response.Header.Get("X-Segmented-Object-Size"); segSize != "" {
-			if (*v).SegmentedObjectSize, err = strconv.ParseInt(segSize, 10, 0); err != nil {
+			if v.SegmentedObjectSize, err = strconv.ParseInt(segSize, 10, 0); err != nil {
 				logs.Warningf("Could not convert header X-Segmented-Object-Size to integer: %w", err)
-				(*v).SegmentedObjectSize = -1
+				v.SegmentedObjectSize = -1
 			}
 		} else {
-			(*v).SegmentedObjectSize = -1
+			v.SegmentedObjectSize = -1
 		}
 
 		_, _ = io.Copy(io.Discard, response.Body)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -71,6 +71,7 @@ var GetAllRepositories = func() []string {
 	for key := range allRepositories {
 		names = append(names, key)
 	}
+
 	return names
 }
 
@@ -80,6 +81,7 @@ var GetEnabledRepositories = func() []string {
 	for key := range hi.repositories {
 		names = append(names, key)
 	}
+
 	return names
 }
 
@@ -104,6 +106,7 @@ var GetEnv = func(name string, verifyURL bool) (string, error) {
 			return "", fmt.Errorf("Environment variable %s not a valid URL: %w", name, err)
 		}
 	}
+
 	return env, nil
 }
 
@@ -115,6 +118,7 @@ var validURL = func(value string) error {
 	if u.Scheme != "https" {
 		return fmt.Errorf("%s does not have scheme 'https'", value)
 	}
+
 	return nil
 }
 
@@ -127,6 +131,7 @@ func GetCommonEnvs() (err error) {
 	if hi.sdsToken, err = GetEnv("SDS_ACCESS_TOKEN", false); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -141,6 +146,7 @@ func InitializeCache() error {
 	if err != nil {
 		return fmt.Errorf("Could not create cache: %w", err)
 	}
+
 	return nil
 }
 
@@ -180,6 +186,7 @@ func InitializeClient() error {
 	}
 
 	logs.Debug("Initializing HTTP client successful")
+
 	return nil
 }
 
@@ -189,6 +196,7 @@ var testURL = func(url string) error {
 		return err
 	}
 	response.Body.Close()
+
 	return nil
 }
 
@@ -210,6 +218,7 @@ var ValidateLogin = func(username, password string) (bool, error) {
 	if err == nil {
 		hi.repositories[SDSubmit] = allRepositories[SDSubmit]
 	}
+
 	return true, err
 }
 
@@ -335,6 +344,7 @@ var MakeRequest = func(url string, query, headers map[string]string, body io.Rea
 	}
 
 	logs.Debugf("Request %s returned a response", escapedURL)
+
 	return nil
 }
 
@@ -382,6 +392,7 @@ var DownloadData = func(nodes []string, path string, start int64, end int64, max
 		if endofst > int64(len(buf)) {
 			endofst = int64(len(buf))
 		}
+
 		return buf[ofst:endofst], nil
 	}
 
@@ -390,6 +401,7 @@ var DownloadData = func(nodes []string, path string, start int64, end int64, max
 		endofst = int64(len(ret))
 	}
 	logs.Debugf("Retrieved file %s from cache, with coordinates [%d, %d)", path, start, end)
+
 	return ret[ofst:endofst], nil
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -275,8 +275,8 @@ var MakeRequest = func(url string, query, headers map[string]string, body io.Rea
 		request.Header.Set(k, v)
 	}
 
-	escapedURL := strings.Replace(request.URL.EscapedPath(), "\n", "", -1)
-	escapedURL = strings.Replace(escapedURL, "\r", "", -1)
+	escapedURL := strings.ReplaceAll(request.URL.EscapedPath(), "\n", "")
+	escapedURL = strings.ReplaceAll(escapedURL, "\r", "")
 
 	// Execute HTTP request
 	// retry the request as specified by hi.httpRetry variable

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -31,12 +31,14 @@ func (c *mockCache) Get(key string) (any, bool) {
 	if c.key == key && c.data != nil {
 		return c.data, true
 	}
+
 	return nil, false
 }
 
 func (c *mockCache) Set(key string, value any, cost int64, ttl time.Duration) bool {
 	c.key = key
 	c.data = value.([]byte)
+
 	return true
 }
 
@@ -52,6 +54,7 @@ func (r *mockRepository) getEnvs() error { return r.envError }
 
 func (r *mockRepository) downloadData(nodes []string, buf any, start, end int64) error {
 	_, _ = io.ReadFull(bytes.NewReader(r.mockDownloadDataBuf), buf.([]byte))
+
 	return r.mockDownloadDataError
 }
 
@@ -229,11 +232,13 @@ func TestGetCommonEnv(t *testing.T) {
 					if tt.certs == "" {
 						return "", errExpected
 					}
+
 					return tt.certs, nil
 				}
 				if tt.token == "" {
 					return "", errExpected
 				}
+
 				return tt.token, nil
 			}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -677,7 +677,7 @@ func TestMakeRequest_PutRequestNil_And_ReadAll_Error(t *testing.T) {
 	hi.client = server.Client()
 
 	var buf []byte
-	var empty *os.File = nil
+	var empty *os.File
 	errStr := "Copying response failed: unexpected EOF"
 	err := MakeRequest(server.URL, nil, nil, empty, &buf)
 	if err == nil {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -175,15 +175,16 @@ func TestGetEnv(t *testing.T) {
 			value, err := GetEnv(tt.envName, tt.verifyURL)
 			os.Unsetenv(tt.envName)
 
-			if tt.errText == "" {
+			switch {
+			case tt.errText == "":
 				if err != nil {
 					t.Errorf("Returned unexpected err: %s", err.Error())
 				} else if value != tt.envValue {
 					t.Errorf("Environment variable has incorrect value. Expected=%s, received=%s", tt.envValue, value)
 				}
-			} else if err == nil {
+			case err == nil:
 				t.Error("Function should have returned error")
-			} else if err.Error() != tt.errText {
+			case err.Error() != tt.errText:
 				t.Errorf("Function returned incorrect error\nExpected=%s\nReceived=%s", tt.errText, err.Error())
 			}
 		})
@@ -244,17 +245,19 @@ func TestGetCommonEnv(t *testing.T) {
 
 			err := GetCommonEnvs()
 
-			if strings.HasPrefix(tt.testname, "OK") {
-				if err != nil {
+			switch {
+			case strings.HasPrefix(tt.testname, "OK"):
+				switch {
+				case err != nil:
 					t.Errorf("Unexpected error: %s", err.Error())
-				} else if tt.certs != hi.certPath {
+				case tt.certs != hi.certPath:
 					t.Errorf("Incorrect certificate path. Expected=%s, received=%s", tt.certs, hi.certPath)
-				} else if tt.token != hi.sdsToken {
+				case tt.token != hi.sdsToken:
 					t.Errorf("Incorrect SDS access token. Expected=%s, received=%s", tt.token, hi.sdsToken)
 				}
-			} else if err == nil {
+			case err == nil:
 				t.Errorf("Function should have returned error")
-			} else if err.Error() != errExpected.Error() {
+			case err.Error() != errExpected.Error():
 				t.Errorf("Incorrect return value\nExpected=%s\nReceived=%s", errExpected.Error(), err.Error())
 			}
 		})
@@ -649,15 +652,16 @@ func TestMakeRequest(t *testing.T) {
 				ret = objects
 			}
 
-			if tt.errText != "" {
+			switch {
+			case tt.errText != "":
 				if err == nil {
 					t.Errorf("Function did not return error")
 				} else if err.Error() != tt.errText {
 					t.Errorf("Function returned incorrect error\nExpected=%s\nReceived=%s", tt.errText, err.Error())
 				}
-			} else if err != nil {
+			case err != nil:
 				t.Errorf("Function returned unexpected error: %s", err.Error())
-			} else if !reflect.DeepEqual(tt.expectedBody, ret) {
+			case !reflect.DeepEqual(tt.expectedBody, ret):
 				t.Errorf("Incorrect response body\nExpected=%v\nReceived=%v", tt.expectedBody, ret)
 			}
 

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -151,11 +151,12 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 	token := c.sTokens[nodes[0]]
 	headers := map[string]string{"X-Project-ID": token.ProjectID, "X-Authorization": "Bearer " + token.Token}
 	path := c.url + "/project/" + url.PathEscape(nodes[0])
-	if len(nodes) == 1 {
+	switch len(nodes) {
+	case 1:
 		path += "/containers"
-	} else if len(nodes) == 2 {
+	case 2:
 		path += "/container/" + url.PathEscape(nodes[1]) + "/objects"
-	} else {
+	default:
 		return nil, nil
 	}
 

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -64,6 +64,7 @@ func (c *connecter) getProjects(url, token string) ([]Metadata, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to retrieve %s projects: %w", SDConnect, err)
 	}
+
 	return projects, nil
 }
 
@@ -80,6 +81,7 @@ func (c *connecter) getSTokens(projects []Metadata, url, token string) map[strin
 		token := sToken{}
 		if err := MakeRequest(url+"/token", query, headers, nil, &token); err != nil {
 			logs.Warningf("Failed to retrieve %s scoped token for %s: %w", SDConnect, projects[i].Name, err)
+
 			continue
 		}
 
@@ -88,6 +90,7 @@ func (c *connecter) getSTokens(projects []Metadata, url, token string) map[strin
 	}
 
 	logs.Infof("Fetching %s tokens finished", SDConnect)
+
 	return newSTokens
 }
 
@@ -104,6 +107,7 @@ func (c *sdConnectInfo) getEnvs() error {
 	if err := testURL(c.url); err != nil {
 		return fmt.Errorf("Cannot connect to %s API: %w", SDConnect, err)
 	}
+
 	return nil
 }
 
@@ -120,6 +124,7 @@ func (c *sdConnectInfo) validateLogin(auth ...string) error {
 		}
 		logs.Infof("Retrieved %d %s project(s)", len(c.projects), SDConnect)
 		c.sTokens = c.getSTokens(c.projects, c.url, c.token)
+
 		return nil
 	}
 
@@ -130,6 +135,7 @@ func (c *sdConnectInfo) validateLogin(auth ...string) error {
 	if errors.As(err, &re) && re.StatusCode == 500 {
 		return fmt.Errorf("%s is not available, please contact CSC servicedesk: %w", SDConnect, err)
 	}
+
 	return fmt.Errorf("Error occurred for %s: %w", SDConnect, err)
 }
 
@@ -166,6 +172,7 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 	}
 
 	logs.Infof("Retrieved metadata for %s", fsPath)
+
 	return meta, nil
 }
 
@@ -174,8 +181,10 @@ func (c *sdConnectInfo) tokenExpired(err error) bool {
 	if errors.As(err, &re) && re.StatusCode == 401 {
 		logs.Infof("%s tokens no longer valid. Fetching them again", SDConnect)
 		c.sTokens = c.getSTokens(c.projects, c.url, c.token)
+
 		return true
 	}
+
 	return false
 }
 
@@ -207,6 +216,7 @@ func (c *sdConnectInfo) updateAttributes(nodes []string, path string, attr any) 
 			logs.Warningf("API returned header 'X-Decrypted' even though size of object %s is too small", path)
 		}
 	}
+
 	return nil
 }
 
@@ -232,8 +242,10 @@ func (c *sdConnectInfo) downloadData(nodes []string, buffer any, start, end int6
 		token = c.sTokens[nodes[0]]
 		headers["X-Project-ID"] = token.ProjectID
 		headers["X-Authorization"] = "Bearer " + token.Token
+
 		return MakeRequest(path, query, headers, nil, buffer)
 	}
+
 	return err
 }
 

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -270,7 +270,7 @@ var calculateDecryptedSize = func(fileSize, headerSize int64) int64 {
 	// the last block can be smaller than 64kiB
 	remainder := bodySize%cipherBlockSize - macSize
 	if remainder < 0 {
-		remainder = remainder + macSize
+		remainder += macSize
 	}
 
 	// Add the previous info back together

--- a/internal/api/sdconnect_test.go
+++ b/internal/api/sdconnect_test.go
@@ -170,9 +170,10 @@ func Test_SDConnect_GetEnvs(t *testing.T) {
 			mockGetEnv: func(s string, b bool) (string, error) {
 				if s != "FS_SD_CONNECT_API" {
 					return "https://metadata.csc.fi", nil
-				} else {
-					return "https://data.csc.fi", nil
 				}
+
+				return "https://data.csc.fi", nil
+
 			},
 			mockTestURL: func(s string) error {
 				return nil

--- a/internal/api/sdconnect_test.go
+++ b/internal/api/sdconnect_test.go
@@ -22,6 +22,7 @@ func (c *mockConnecter) getProjects(string, string) ([]Metadata, error) {
 	if c.projectsErr != nil {
 		return nil, fmt.Errorf("getProjects error: %w", c.projectsErr)
 	}
+
 	return c.projects, nil
 }
 
@@ -60,6 +61,7 @@ func Test_SDConnect_GetProjects(t *testing.T) {
 				switch v := ret.(type) {
 				case *[]Metadata:
 					*v = tt.expectedMetaData
+
 					return nil
 				default:
 					return fmt.Errorf("ret has incorrect type %v, expected *[]Metadata", reflect.TypeOf(v))
@@ -136,6 +138,7 @@ func Test_SDConnect_GetSTokens(t *testing.T) {
 				switch v := ret.(type) {
 				case *sToken:
 					*v = tt.sTokens[query["project"]]
+
 					return nil
 				default:
 					return fmt.Errorf("ret has incorrect type %v, expected *SToken", reflect.TypeOf(v))
@@ -391,6 +394,7 @@ func Test_SDConnect_GetNthLevel_Pass_1Node(t *testing.T) {
 	defer func() { MakeRequest = origMakeRequest }()
 	MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
 		_ = json.NewDecoder(bytes.NewReader([]byte(`[{"bytes":100,"name":"thingy1"}]`))).Decode(ret)
+
 		return nil
 	}
 	sd := &sdConnectInfo{}
@@ -414,6 +418,7 @@ func Test_SDConnect_GetNthLevel_Pass_2Node(t *testing.T) {
 	defer func() { MakeRequest = origMakeRequest }()
 	MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
 		_ = json.NewDecoder(bytes.NewReader([]byte(`[{"bytes":100,"name":"thingy2"}]`))).Decode(ret)
+
 		return nil
 	}
 	sd := &sdConnectInfo{}
@@ -438,8 +443,10 @@ func Test_SDConnect_GetNthLevel_Pass_TokenExpired(t *testing.T) {
 	MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
 		if token, ok := headers["X-Authorization"]; ok && token == "Bearer freshToken" {
 			_ = json.NewDecoder(bytes.NewReader([]byte(`[{"bytes":100,"name":"thingy3"}]`))).Decode(ret)
+
 			return nil
 		}
+
 		return &RequestError{http.StatusUnauthorized}
 	}
 	mockC := &mockConnecter{sTokens: map[string]sToken{"project": {"freshToken", "projectID"}}}
@@ -519,6 +526,7 @@ func Test_SDConnect_UpdateAttributes(t *testing.T) {
 					v.Decrypted = tt.decrypted
 					v.SegmentedObjectSize = tt.segmentedObjectSize
 					v.HeaderSize = 0
+
 					return nil
 				default:
 					return fmt.Errorf("ret has incorrect type %v, expected *SpecialHeaders", reflect.TypeOf(v))
@@ -599,6 +607,7 @@ func Test_SDConnect_DownloadData_Pass(t *testing.T) {
 			t.Errorf("Function failed, expected=%s, received=%s", expectedHeaders, headers)
 		}
 		_, _ = io.ReadFull(bytes.NewReader(expectedBody), ret.([]byte))
+
 		return nil
 	}
 	sd := &sdConnectInfo{sTokens: map[string]sToken{"project": {"token", "project"}}}
@@ -628,8 +637,10 @@ func Test_SDConnect_DownloadData_Pass_TokenExpired(t *testing.T) {
 				t.Errorf("Function failed\nExpected=%s\nReceived=%s", expectedHeaders, headers)
 			}
 			_, _ = io.ReadFull(bytes.NewReader(expectedBody), ret.([]byte))
+
 			return nil
 		}
+
 		return &RequestError{http.StatusUnauthorized}
 	}
 	mockC := &mockConnecter{sTokens: map[string]sToken{"project": {"freshToken", "projectID"}}}

--- a/internal/api/sdconnect_test.go
+++ b/internal/api/sdconnect_test.go
@@ -534,7 +534,7 @@ func Test_SDConnect_UpdateAttributes(t *testing.T) {
 				}
 			}
 
-			var size int64 = tt.initSize
+			var size = tt.initSize
 			sd := &sdConnectInfo{}
 			err := sd.updateAttributes([]string{"path", "to", "file"}, "path/to/file", &size)
 

--- a/internal/api/sdsubmit.go
+++ b/internal/api/sdsubmit.go
@@ -66,6 +66,7 @@ func (s *submitter) getDatasets(urlStr string) ([]string, error) {
 	}
 
 	logs.Infof("Retrieved %d %s dataset(s) from API %s", len(datasets), SDSubmit, urlStr)
+
 	return datasets, nil
 }
 
@@ -99,6 +100,7 @@ func (s *submitter) getFiles(fsPath, urlStr, dataset string) ([]Metadata, error)
 	}
 
 	logs.Infof("Retrieved files for dataset %s", fsPath)
+
 	return metadata, nil
 }
 
@@ -122,6 +124,7 @@ func (s *sdSubmitInfo) getEnvs() error {
 			return fmt.Errorf("Cannot connect to %s registered API: %w", SDSubmit, err)
 		}
 	}
+
 	return nil
 }
 
@@ -160,6 +163,7 @@ func (s *sdSubmitInfo) validateLogin(auth ...string) error {
 			return fmt.Errorf("No datasets found for %s", SDSubmit)
 		}
 	}
+
 	return nil
 }
 
@@ -176,12 +180,14 @@ func (s *sdSubmitInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata, 
 			datasets[i] = Metadata{Name: ds, Bytes: -1}
 			i++
 		}
+
 		return datasets, nil
 	case 1:
 		idx, ok := s.datasets[nodes[0]]
 		if !ok {
 			return nil, fmt.Errorf("Tried to request files for invalid dataset %s", fsPath)
 		}
+
 		return s.getFiles(fsPath, s.urls[idx], nodes[0])
 	default:
 		return nil, nil
@@ -207,5 +213,6 @@ func (s *sdSubmitInfo) downloadData(nodes []string, buffer any, start, end int64
 
 	// Request data
 	path := s.urls[idx] + "/files/" + s.fileIDs[nodes[0]+"_"+nodes[1]]
+
 	return MakeRequest(path, query, nil, nil, buffer)
 }

--- a/internal/api/sdsubmit.go
+++ b/internal/api/sdsubmit.go
@@ -155,11 +155,12 @@ func (s *sdSubmitInfo) validateLogin(auth ...string) error {
 	}
 
 	if len(s.datasets) == 0 {
-		if count500 > 0 {
+		switch {
+		case count500 > 0:
 			return fmt.Errorf("%s is not available, please contact CSC servicedesk", SDSubmit)
-		} else if count > 0 {
+		case count > 0:
 			return fmt.Errorf("Error(s) occurred for %s", SDSubmit)
-		} else {
+		default:
 			return fmt.Errorf("No datasets found for %s", SDSubmit)
 		}
 	}

--- a/internal/api/sdsubmit_test.go
+++ b/internal/api/sdsubmit_test.go
@@ -26,17 +26,19 @@ type mockSubmitter struct {
 func (s *mockSubmitter) getDatasets(urlStr string) ([]string, error) {
 	if urlStr == s.mockUrlOK {
 		return s.mockDatasets, nil
-	} else {
-		return nil, s.mockError
 	}
+
+	return nil, s.mockError
+
 }
 
 func (s *mockSubmitter) getFiles(fsPath, urlStr, dataset string) ([]Metadata, error) {
 	if urlStr == s.mockUrlOK {
 		return s.mockFiles, nil
-	} else {
-		return nil, s.mockError
 	}
+
+	return nil, s.mockError
+
 }
 
 func Test_SDSubmit_GetDatasets_Fail(t *testing.T) {

--- a/internal/api/sdsubmit_test.go
+++ b/internal/api/sdsubmit_test.go
@@ -17,14 +17,14 @@ const constantError = "some error"
 
 type mockSubmitter struct {
 	submittable
-	mockUrlOK    string
+	mockURLOK    string
 	mockDatasets []string
 	mockFiles    []Metadata
 	mockError    error
 }
 
 func (s *mockSubmitter) getDatasets(urlStr string) ([]string, error) {
-	if urlStr == s.mockUrlOK {
+	if urlStr == s.mockURLOK {
 		return s.mockDatasets, nil
 	}
 
@@ -33,7 +33,7 @@ func (s *mockSubmitter) getDatasets(urlStr string) ([]string, error) {
 }
 
 func (s *mockSubmitter) getFiles(fsPath, urlStr, dataset string) ([]Metadata, error) {
-	if urlStr == s.mockUrlOK {
+	if urlStr == s.mockURLOK {
 		return s.mockFiles, nil
 	}
 
@@ -318,7 +318,7 @@ func Test_SDSubmit_GetEnvs_Pass(t *testing.T) {
 
 func Test_SDSubmit_ValidateLogin_401_Error(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "good", mockError: &RequestError{http.StatusUnauthorized}}
+	ms := &mockSubmitter{mockURLOK: "good", mockError: &RequestError{http.StatusUnauthorized}}
 	s := &sdSubmitInfo{submittable: ms, urls: []string{"bad"}}
 
 	// Test
@@ -334,7 +334,7 @@ func Test_SDSubmit_ValidateLogin_401_Error(t *testing.T) {
 
 func Test_SDSubmit_ValidateLogin_500_Error(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "good", mockError: &RequestError{http.StatusInternalServerError}}
+	ms := &mockSubmitter{mockURLOK: "good", mockError: &RequestError{http.StatusInternalServerError}}
 	s := &sdSubmitInfo{submittable: ms, urls: []string{"bad"}}
 
 	expectedError := "SD Apply is not available, please contact CSC servicedesk"
@@ -349,7 +349,7 @@ func Test_SDSubmit_ValidateLogin_500_Error(t *testing.T) {
 
 func Test_SDSubmit_ValidateLogin_500_And_Pass(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "good", mockError: &RequestError{http.StatusInternalServerError},
+	ms := &mockSubmitter{mockURLOK: "good", mockError: &RequestError{http.StatusInternalServerError},
 		mockDatasets: []string{"dataset1", "dataset2", "dataset3"}}
 	s := &sdSubmitInfo{submittable: ms, urls: []string{"bad", "good"}}
 
@@ -367,7 +367,7 @@ func Test_SDSubmit_ValidateLogin_500_And_Pass(t *testing.T) {
 
 func Test_SDSubmit_ValidateLogin_No_Responses(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "good", mockError: &RequestError{http.StatusBadGateway}}
+	ms := &mockSubmitter{mockURLOK: "good", mockError: &RequestError{http.StatusBadGateway}}
 	s := &sdSubmitInfo{submittable: ms, urls: []string{"bad"}}
 
 	// Test
@@ -383,7 +383,7 @@ func Test_SDSubmit_ValidateLogin_No_Responses(t *testing.T) {
 
 func Test_SDSubmit_ValidateLogin_Pass_Found(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "good", mockDatasets: []string{"dataset1", "dataset2", "dataset3"}}
+	ms := &mockSubmitter{mockURLOK: "good", mockDatasets: []string{"dataset1", "dataset2", "dataset3"}}
 	s := &sdSubmitInfo{submittable: ms, urls: []string{"good"}}
 
 	// Test
@@ -400,7 +400,7 @@ func Test_SDSubmit_ValidateLogin_Pass_Found(t *testing.T) {
 
 func Test_SDSubmit_ValidateLogin_Pass_None(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "good", mockDatasets: []string{}}
+	ms := &mockSubmitter{mockURLOK: "good", mockDatasets: []string{}}
 	s := &sdSubmitInfo{submittable: ms, urls: []string{"good"}}
 
 	// Test
@@ -473,7 +473,7 @@ func Test_SDSubmit_GetNthLevel_Fail_1(t *testing.T) {
 
 func Test_SDSubmit_GetNthLevel_Pass_1(t *testing.T) {
 	// Mock
-	ms := &mockSubmitter{mockUrlOK: "someurl", mockFiles: []Metadata{{Name: "file1.txt"}}}
+	ms := &mockSubmitter{mockURLOK: "someurl", mockFiles: []Metadata{{Name: "file1.txt"}}}
 	s := &sdSubmitInfo{
 		submittable: ms,
 		datasets:    map[string]int{"dataset1": 0, "dataset2": 1},

--- a/internal/api/sdsubmit_test.go
+++ b/internal/api/sdsubmit_test.go
@@ -66,6 +66,7 @@ func Test_SDSubmit_GetDatasets_Pass(t *testing.T) {
 	defer func() { MakeRequest = origMakeRequest }()
 	MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
 		_ = json.NewDecoder(bytes.NewReader([]byte(`["dataset1","dataset2","dataset3"]`))).Decode(ret)
+
 		return nil
 	}
 
@@ -130,6 +131,7 @@ func Test_SDSubmit_GetFiles_Pass(t *testing.T) {
 	defer func() { MakeRequest = origMakeRequest }()
 	MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
 		_ = json.NewDecoder(bytes.NewReader(testFileJSON)).Decode(ret)
+
 		return nil
 	}
 
@@ -178,6 +180,7 @@ func Test_SDSubmit_GetFiles_Split_Pass(t *testing.T) {
 			return fmt.Errorf("makeRequest() received incorrect scheme in query\nExpected=%s\nReceived=%s", "https", scheme)
 		}
 		_ = json.NewDecoder(bytes.NewReader(testFileJSON)).Decode(ret)
+
 		return nil
 	}
 
@@ -531,6 +534,7 @@ func Test_SDSubmit_DownloadData_Pass(t *testing.T) {
 	defer func() { MakeRequest = origMakeRequest }()
 	MakeRequest = func(url string, query, headers map[string]string, body io.Reader, ret any) error {
 		_, _ = io.ReadFull(bytes.NewReader(expectedData), ret.([]byte))
+
 		return nil
 	}
 	s := sdSubmitInfo{

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -70,6 +70,7 @@ func (s *storage) Set(key string, value any, cost int64, ttl time.Duration) bool
 	if ttl == -1 {
 		ttl = RistrettoCacheTTL
 	}
+
 	return s.cache.SetWithTTL(key, value, cost, ttl)
 }
 

--- a/internal/filesystem/enabled.go
+++ b/internal/filesystem/enabled.go
@@ -39,11 +39,11 @@ func (fs *Fuse) Open(path string, flags int) (errc int, fh uint64) {
 				n.node.decryptionChecked = true
 
 				return -fuse.EACCES, ^uint64(0)
-			} else {
-				logs.Errorf("Encryption status and segmented object size of object %s could not be determined: %w", path, err)
-
-				return -fuse.EIO, ^uint64(0)
 			}
+			logs.Errorf("Encryption status and segmented object size of object %s could not be determined: %w", path, err)
+
+			return -fuse.EIO, ^uint64(0)
+
 		} else if n.node.stat.Size != newSize {
 			fs.updateNodeSizesAlongPath(path, n.node.stat.Size-newSize, fuse.Now())
 		}

--- a/internal/filesystem/enabled_test.go
+++ b/internal/filesystem/enabled_test.go
@@ -113,6 +113,7 @@ func TestOpen_Decryption_Check(t *testing.T) {
 					return fmt.Errorf("updateAttributes() was called with incorrect attribute. Expected type *int64, got %v", reflect.TypeOf(attr))
 				}
 				*size = tt.sizes[len(tt.sizes)-1]
+
 				return nil
 			}
 
@@ -452,6 +453,7 @@ func TestReaddir(t *testing.T) {
 		} else {
 			t.Errorf("Invalid name %q", name)
 		}
+
 		return false
 	}
 

--- a/internal/filesystem/enabled_test.go
+++ b/internal/filesystem/enabled_test.go
@@ -41,17 +41,17 @@ func TestOpen(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
 			errc, fh := fs.Open(tt.path, 0)
-
-			if errc != tt.errc {
+			switch {
+			case errc != tt.errc:
 				t.Errorf("Error code incorrect. Expected %d, received %d", tt.errc, errc)
-			} else if tt.node != nil {
+			case tt.node != nil:
 				if fh != tt.node.stat.Ino {
 					t.Errorf("File handle incorrect. Expected %d, received %d", tt.node.stat.Ino, fh)
 				} else if fs.openmap[tt.node.stat.Ino].node != tt.node {
 					t.Errorf("Filesystem's openmap has incorrect value for file handle %d. Expected address %p, received %p",
 						fh, tt.node, fs.openmap[tt.node.stat.Ino].node)
 				}
-			} else if fh != ^uint64(0) {
+			case fh != ^uint64(0):
 				t.Errorf("File handle incorrect. Expected %d, received %d", ^uint64(0), fh)
 			}
 		})
@@ -123,14 +123,14 @@ func TestOpen_Decryption_Check(t *testing.T) {
 
 			path := strings.Join(tt.nodes, "/")
 			errc, fh := fs.Open(path, 0)
-
-			if errc != 0 {
+			switch {
+			case errc != 0:
 				t.Errorf("Error code incorrect for path %s. Expected 0, received %d", path, errc)
-			} else if fh != tt.fh {
+			case fh != tt.fh:
 				t.Errorf("File handle incorrect for path %s. Expected %d, received %d", path, tt.fh, fh)
-			} else if !fs.openmap[fh].node.decryptionChecked {
+			case !fs.openmap[fh].node.decryptionChecked:
 				t.Errorf("Field 'decyptionChecked' is not true for node %s", path)
-			} else {
+			default:
 				prnt := fs.root
 				for i := range tt.nodes {
 					prnt = prnt.chld[tt.nodes[i]]
@@ -185,11 +185,12 @@ func TestOpen_Decryption_Check_Error(t *testing.T) {
 			path := strings.Join(tt.nodes, "/")
 			errc, fh := fs.Open(path, 0)
 
-			if errc != tt.errc {
+			switch {
+			case errc != tt.errc:
 				t.Errorf("Error code incorrect for path %s. Expected %d, received %d", path, tt.errc, errc)
-			} else if fh != ^uint64(0) {
+			case fh != ^uint64(0):
 				t.Errorf("File handle incorrect for path %s. Expected %d, received %d", path, ^uint64(0), fh)
-			} else {
+			default:
 				node := fs.root
 				for i := range tt.nodes {
 					node = node.chld[tt.nodes[i]]
@@ -229,16 +230,17 @@ func TestOpendir(t *testing.T) {
 		t.Run(tt.testname, func(t *testing.T) {
 			errc, fh := fs.Opendir(tt.path)
 
-			if errc != tt.errc {
+			switch {
+			case errc != tt.errc:
 				t.Errorf("Error code incorrect. Expected %d, received %d", tt.errc, errc)
-			} else if tt.node != nil {
+			case tt.node != nil:
 				if fh != tt.node.stat.Ino {
 					t.Errorf("File handle incorrect. Expected %d, received %d", tt.node.stat.Ino, fh)
 				} else if fs.openmap[tt.node.stat.Ino].node != tt.node {
 					t.Errorf("Filesystem's openmap has incorrect value for file handle %d. Expected address %p, received %p",
 						fh, tt.node, fs.openmap[tt.node.stat.Ino].node)
 				}
-			} else if fh != ^uint64(0) {
+			case fh != ^uint64(0):
 				t.Errorf("File handle incorrect. Expected %d, received %d", ^uint64(0), fh)
 			}
 		})
@@ -251,20 +253,24 @@ func TestRelease(t *testing.T) {
 	node := fs.root.chld["Rep2"].chld["example.com"].chld["tiedosto"]
 	fs.openmap[node.stat.Ino] = nodeAndPath{node: node}
 	node.opencnt = 2
-
-	if ret := fs.Release("Rep2/example.com/tiedosto", node.stat.Ino); ret != 0 {
+	ret := fs.Release("Rep2/example.com/tiedosto", node.stat.Ino)
+	switch {
+	case ret != 0:
 		t.Errorf("Return value incorrect. Expected=0, received=%d", ret)
-	} else if node.opencnt != 1 {
+	case node.opencnt != 1:
 		t.Errorf("Node that was closed should have opencnt=1, received=%d", node.opencnt)
-	} else if fs.openmap[node.stat.Ino].node == nil {
+	case fs.openmap[node.stat.Ino].node == nil:
 		t.Errorf("Node should not have been removed from openmap")
 	}
 
-	if ret := fs.Release("Rep2/example.com/tiedosto", node.stat.Ino); ret != 0 {
+	ret = fs.Release("Rep2/example.com/tiedosto", node.stat.Ino)
+
+	switch {
+	case ret != 0:
 		t.Errorf("Return value incorrect. Expected=0, received=%d", ret)
-	} else if node.opencnt != 0 {
+	case node.opencnt != 0:
 		t.Errorf("Node that was closed should have opencnt=0, received=%d", node.opencnt)
-	} else if fs.openmap[node.stat.Ino].node != nil {
+	case fs.openmap[node.stat.Ino].node != nil:
 		t.Errorf("Node should have been removed from openmap")
 	}
 
@@ -279,20 +285,24 @@ func TestReleaseDir(t *testing.T) {
 	node := fs.root.chld["Rep1"].chld["child_1"].chld["kansio"]
 	fs.openmap[node.stat.Ino] = nodeAndPath{node: node}
 	node.opencnt = 2
-
-	if ret := fs.Releasedir("Rep1/child_1/kansio", node.stat.Ino); ret != 0 {
+	ret := fs.Releasedir("Rep1/child_1/kansio", node.stat.Ino)
+	switch {
+	case ret != 0:
 		t.Errorf("Return value incorrect. Expected=0, received=%d", ret)
-	} else if node.opencnt != 1 {
+	case node.opencnt != 1:
 		t.Errorf("Node that was closed should have opencnt=1, received=%d", node.opencnt)
-	} else if fs.openmap[node.stat.Ino].node == nil {
+	case fs.openmap[node.stat.Ino].node == nil:
 		t.Errorf("Node should not have been removed from openmap")
 	}
 
-	if ret := fs.Releasedir("Rep1/child_1/kansio", node.stat.Ino); ret != 0 {
+	ret = fs.Releasedir("Rep1/child_1/kansio", node.stat.Ino)
+
+	switch {
+	case ret != 0:
 		t.Errorf("Return value incorrect. Expected=0, received=%d", ret)
-	} else if node.opencnt != 0 {
+	case node.opencnt != 0:
 		t.Errorf("Node that was closed should have opencnt=0, received=%d", node.opencnt)
-	} else if fs.openmap[node.stat.Ino].node != nil {
+	case fs.openmap[node.stat.Ino].node != nil:
 		t.Errorf("Node should have been removed from openmap")
 	}
 

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -123,15 +123,16 @@ func MountFilesystem(fs *Fuse, mount string) {
 	host = fuse.NewFileSystemHost(fs)
 
 	options := []string{}
-	if runtime.GOOS == "darwin" {
+	switch runtime.GOOS {
+	case "darwin":
 		options = append(options, "-o", "defer_permissions")
 		options = append(options, "-o", "volname="+path.Base(mount))
 		options = append(options, "-o", "attr_timeout=0") // This causes the fuse to call getattr between open and read
 		options = append(options, "-o", "iosize=262144")  // Value not optimized
-	} else if runtime.GOOS == "linux" {
+	case "linux":
 		options = append(options, "-o", "attr_timeout=0") // This causes the fuse to call getattr between open and read
 		options = append(options, "-o", "auto_unmount")
-	} else if runtime.GOOS == "windows" {
+	case "windows":
 		options = append(options, "-o", "umask=0222")
 		options = append(options, "-o", "uid=-1")
 		options = append(options, "-o", "gid=-1")

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -114,6 +114,7 @@ func InitializeFileSystem(send func(string, string)) *Fuse {
 			}
 		}
 	}
+
 	return &fs
 }
 
@@ -168,6 +169,7 @@ func (fs *Fuse) FilesOpen(mount string) bool {
 			}
 		}
 	}
+
 	return false
 }
 
@@ -196,6 +198,7 @@ func (fs *Fuse) PopulateFilesystem(send func(string, string, int)) {
 
 				if err != nil {
 					logs.Error(err)
+
 					return
 				}
 
@@ -266,6 +269,7 @@ var removeInvalidChars = func(str string) string {
 
 	// Remove characters which may interfere with filesystem structure
 	r := strings.NewReplacer(forReplacer...)
+
 	return r.Replace(str)
 }
 
@@ -277,6 +281,7 @@ func calculateFinalSize(n *node, path string) int64 {
 	for key, value := range n.chld {
 		n.stat.Size += calculateFinalSize(value, path+"/"+key)
 	}
+
 	return n.stat.Size
 }
 
@@ -294,12 +299,14 @@ var createObjects = func(id int, jobs <-chan containerInfo, wg *sync.WaitGroup, 
 		c := fs.getNode(containerPath, ^uint64(0))
 		if c.node == nil {
 			logs.Errorf("Bug in code? Cannot find node %s", containerPath)
+
 			continue
 		}
 
 		objects, err := api.GetNthLevel(c.path[0], containerPath, c.path[1], c.path[2])
 		if err != nil {
 			logs.Error(err)
+
 			continue
 		}
 
@@ -319,6 +326,7 @@ func (fs *Fuse) createLevel(prnt *node, objects []api.Metadata, prntPath string,
 	for _, obj := range objects {
 		// Prevent the creation of objects that are actually empty directories
 		if strings.HasSuffix(obj.Name, "/") {
+
 			continue
 		}
 
@@ -330,6 +338,7 @@ func (fs *Fuse) createLevel(prnt *node, objects []api.Metadata, prntPath string,
 			objectPath := prntPath + "/" + objectSafe
 			logs.Debugf("Creating file %s", filepath.FromSlash(objectPath))
 			fs.makeNode(prnt, obj, objectPath, fuse.S_IFREG|sRDONLY, tmsp)
+
 			continue
 		}
 
@@ -378,6 +387,7 @@ var newNode = func(ino uint64, mode uint32, uid uint32, gid uint32, tmsp fuse.Ti
 	if fuse.S_IFDIR == self.stat.Mode&fuse.S_IFMT {
 		self.chld = map[string]*node{}
 	}
+
 	return &self
 }
 
@@ -444,6 +454,7 @@ func (fs *Fuse) makeNode(prnt *node, meta api.Metadata, nodePath string, mode ui
 	prnt.chld[name] = n
 	prnt.stat.Ctim = n.stat.Ctim
 	prnt.stat.Mtim = n.stat.Ctim
+
 	return n, name
 }
 
@@ -462,6 +473,7 @@ var lookupNode = func(root *node, path string) (node *node, origPath []string) {
 			}
 		}
 	}
+
 	return
 }
 
@@ -497,6 +509,7 @@ func (fs *Fuse) openNode(path string, dir bool) (int, uint64) {
 	if n.opencnt == 1 {
 		fs.openmap[n.stat.Ino] = nodeAndPath{node: n, path: origPath}
 	}
+
 	return 0, n.stat.Ino
 }
 
@@ -509,14 +522,17 @@ func (fs *Fuse) closeNode(fh uint64) int {
 	if node.opencnt == 0 {
 		delete(fs.openmap, node.stat.Ino)
 	}
+
 	return 0
 }
 
 func (fs *Fuse) getNode(path string, fh uint64) nodeAndPath {
 	if fh == ^uint64(0) {
 		node, origPath := lookupNode(fs.root, path)
+
 		return nodeAndPath{node: node, path: origPath}
 	}
+
 	return fs.openmap[fh]
 }
 
@@ -531,12 +547,15 @@ func (fs *Fuse) GetNodeChildren(path string) []string {
 		chld[i] = value.originalName
 		i++
 	}
+
 	sort.Strings(chld)
+
 	return chld
 }
 
 func (fs *Fuse) synchronize() func() {
 	fs.lock.Lock()
+
 	return func() {
 		fs.lock.Unlock()
 	}

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -22,8 +22,8 @@ import (
 const sRDONLY = 00444
 const numRoutines = 4
 
-var signalBridge func() = nil
-var host *fuse.FileSystemHost = nil
+var signalBridge func()
+var host *fuse.FileSystemHost
 
 // Fuse stores the filesystem structure
 type Fuse struct {

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -243,11 +243,12 @@ func getTestFuse(t *testing.T, sizeUnfinished bool, maxLevel int) (fs *Fuse) {
 	fs.root.stat.Ino = 1
 	fs.openmap = map[uint64]nodeAndPath{1: {fs.root, []string{"path"}}}
 
-	if sizeUnfinished && nodes.Size < 0 {
+	switch {
+	case sizeUnfinished && nodes.Size < 0:
 		fs.root.stat.Size = -1
-	} else if nodes.Size < 0 {
+	case nodes.Size < 0:
 		fs.root.stat.Size = -nodes.Size
-	} else {
+	default:
 		fs.root.stat.Size = nodes.Size
 	}
 
@@ -262,11 +263,12 @@ func assignChildren(n *node, template *[]jsonNode, sizeUnfinished bool, maxLevel
 		n.chld[child.NameSafe].originalName = child.Name
 		n.chld[child.NameSafe].stat.Ino = ino
 
-		if sizeUnfinished && child.Size < 0 {
+		switch {
+		case sizeUnfinished && child.Size < 0:
 			n.chld[child.NameSafe].stat.Size = -1
-		} else if child.Size < 0 {
+		case child.Size < 0:
 			n.chld[child.NameSafe].stat.Size = -child.Size
-		} else {
+		default:
 			n.chld[child.NameSafe].stat.Size = child.Size
 		}
 
@@ -456,19 +458,21 @@ func TestPopulateFilesystem(t *testing.T) {
 			return nil, fmt.Errorf("Third parameter of api.GetNthLevel() should have had length 1, received %v that has length %d", nodes, len(nodes))
 		}
 		if rep == rep1 {
-			if nodes[0] == "child+1" {
+			switch nodes[0] {
+			case "child+1":
 				return []api.Metadata{{Bytes: -1, Name: "kansio"}, {Bytes: 112, Name: "dir+"}}, nil
-			} else if nodes[0] == "child_2" {
+			case "child_2":
 				return []api.Metadata{{Bytes: 151, Name: "dir"}, {Bytes: 65, Name: "+folder"}}, nil
-			} else {
+			default:
 				return nil, fmt.Errorf("api.GetNthLevel() received invalid project %s", rep+"/"+nodes[0])
 			}
 		} else if rep == rep2 {
 			if nodes[0] == "https://example.com" {
 				return []api.Metadata{{Bytes: 5, Name: "tiedosto"}}, nil
-			} else {
-				return nil, fmt.Errorf("api.GetNthLevel() received invalid project %s", rep+"/"+nodes[0])
 			}
+
+			return nil, fmt.Errorf("api.GetNthLevel() received invalid project %s", rep+"/"+nodes[0])
+
 		}
 
 		return nil, fmt.Errorf("api.GetNthLevel() received invalid repository %s", rep)
@@ -711,19 +715,20 @@ func TestNewNode(t *testing.T) {
 				return
 			}
 
-			if node.stat.Ino != tt.ino {
+			switch {
+			case node.stat.Ino != tt.ino:
 				t.Errorf("File serial number incorrect. Expected %d, got %d", tt.ino, node.stat.Ino)
-			} else if node.stat.Mode != mode {
+			case node.stat.Mode != mode:
 				t.Errorf("Mode incorrect. Expected %d, got %d", mode, node.stat.Mode)
-			} else if node.stat.Atim != tt.tmsp {
+			case node.stat.Atim != tt.tmsp:
 				t.Errorf("Atim field incorrect. Expected %q, got %q", tt.tmsp.Time().String(), node.stat.Atim.Time().String())
-			} else if node.stat.Ctim != tt.tmsp {
+			case node.stat.Ctim != tt.tmsp:
 				t.Errorf("Ctim field incorrect. Expected %q, got %q", tt.tmsp.Time().String(), node.stat.Ctim.Time().String())
-			} else if node.stat.Mtim != tt.tmsp {
+			case node.stat.Mtim != tt.tmsp:
 				t.Errorf("Mtim field incorrect. Expected %q, got %q", tt.tmsp.Time().String(), node.stat.Mtim.Time().String())
-			} else if node.stat.Birthtim != tt.tmsp {
+			case node.stat.Birthtim != tt.tmsp:
 				t.Errorf("Birthtim field incorrect. Expected %q, got %q", tt.tmsp.Time().String(), node.stat.Birthtim.Time().String())
-			} else if tt.dir && node.chld == nil {
+			case tt.dir && node.chld == nil:
 				t.Errorf("Node's chld field was not initialized")
 			}
 		})
@@ -766,15 +771,16 @@ func TestLookupNode(t *testing.T) {
 		t.Run(testname, func(t *testing.T) {
 			node, origPath := lookupNode(fs.root, tt.path)
 
-			if tt.nodeMatch == nil {
+			switch {
+			case tt.nodeMatch == nil:
 				if node != nil {
 					t.Errorf("Should not have returned node for path %s", tt.path)
 				}
-			} else if node == nil {
+			case node == nil:
 				t.Errorf("Returned nil for path %s", tt.path)
-			} else if node != tt.nodeMatch {
+			case node != tt.nodeMatch:
 				t.Errorf("Node incorrect for path %q. Expected address %p, got %p", tt.path, tt.nodeMatch, node)
-			} else if !reflect.DeepEqual(origPath, tt.origPath) {
+			case !reflect.DeepEqual(origPath, tt.origPath):
 				t.Errorf("Original path incorrect for path %s\nExpected %v\nReceived %v", tt.path, tt.origPath, origPath)
 			}
 		})

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -252,6 +252,7 @@ func getTestFuse(t *testing.T, sizeUnfinished bool, maxLevel int) (fs *Fuse) {
 	}
 
 	assignChildren(fs.root, nodes.Children, sizeUnfinished, maxLevel, 2)
+
 	return
 }
 
@@ -281,6 +282,7 @@ func assignChildren(n *node, template *[]jsonNode, sizeUnfinished bool, maxLevel
 
 		ino++
 	}
+
 	return ino
 }
 
@@ -368,6 +370,7 @@ func TestInitializeFilesystem(t *testing.T) {
 		n := &node{}
 		n.stat.Mode = mode
 		n.chld = map[string]*node{}
+
 		return n
 	}
 	api.GetEnabledRepositories = func() []string {
@@ -382,6 +385,7 @@ func TestInitializeFilesystem(t *testing.T) {
 		} else if rep == rep2 {
 			return []api.Metadata{{Bytes: 5, Name: "https://example.com"}}, nil
 		}
+
 		return nil, fmt.Errorf("api.GetNthLevel() received invalid repository %q", rep)
 	}
 	removeInvalidChars = func(str string) string {
@@ -443,6 +447,7 @@ func TestPopulateFilesystem(t *testing.T) {
 		n := &node{}
 		n.stat.Mode = mode
 		n.chld = map[string]*node{}
+
 		return n
 	}
 	CheckPanic = func() {}
@@ -465,6 +470,7 @@ func TestPopulateFilesystem(t *testing.T) {
 				return nil, fmt.Errorf("api.GetNthLevel() received invalid project %s", rep+"/"+nodes[0])
 			}
 		}
+
 		return nil, fmt.Errorf("api.GetNthLevel() received invalid repository %s", rep)
 	}
 	removeInvalidChars = func(str string) string {
@@ -477,6 +483,7 @@ func TestPopulateFilesystem(t *testing.T) {
 			nodes := strings.Split(j.containerPath, "/")
 			if len(nodes) != 3 {
 				t.Errorf("Invalid containerPath %s", j.containerPath)
+
 				continue
 			}
 
@@ -486,14 +493,17 @@ func TestPopulateFilesystem(t *testing.T) {
 
 			if _, ok := origFs.root.chld[repository]; !ok {
 				t.Errorf("Invalid repository %s in containerInfo", repository)
+
 				continue
 			}
 			if _, ok := origFs.root.chld[repository].chld[project]; !ok {
 				t.Errorf("Invalid project %s in containerInfo", repository+"/"+project)
+
 				continue
 			}
 			if _, ok := origFs.root.chld[repository].chld[project].chld[container]; !ok {
 				t.Errorf("Invalid container %s in containerInfo", repository+"/"+project+"/"+container)
+
 				continue
 			}
 			for key, value := range origFs.root.chld[repository].chld[project].chld[container].chld {
@@ -508,6 +518,7 @@ func TestPopulateFilesystem(t *testing.T) {
 			return 2
 		}
 		t.Fatalf("api.LevelCount() received invalid repository %s", rep)
+
 		return 0
 	}
 
@@ -542,6 +553,7 @@ func TestCreateObjects(t *testing.T) {
 		n := &node{}
 		n.stat.Mode = mode
 		n.chld = map[string]*node{}
+
 		return n
 	}
 	CheckPanic = func() {}
@@ -558,6 +570,7 @@ func TestCreateObjects(t *testing.T) {
 		if nodes[1] != cont {
 			t.Fatalf("GetNthLevel() received incorrect container %q, expected %q", rep+"/"+pr+"/"+nodes[1], rep+"/"+pr+"/"+cont)
 		}
+
 		return []api.Metadata{{Bytes: 29, Name: "dir1/dir+2/dir3.2.1/file.c4gh"},
 			{Bytes: 1, Name: "dir1/dir+2/dir3.2.1/file/h%e%ll+o"},
 			{Bytes: 1, Name: "dir1/dir5/"},
@@ -694,6 +707,7 @@ func TestNewNode(t *testing.T) {
 
 			if node == nil {
 				t.Error("Node is nil")
+
 				return
 			}
 

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -9,7 +9,7 @@ import (
 )
 
 // signal sends a new log to the LogModel
-var signal func(int, []string) = nil
+var signal func(int, []string)
 
 var log *logrus.Logger
 

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -29,6 +29,7 @@ func SetSignal(fn func(int, []string)) {
 var SetLevel = func(level string) {
 	if logrusLevel, ok := levelMap[strings.ToLower(level)]; ok {
 		log.SetLevel(logrusLevel)
+
 		return
 	}
 
@@ -42,6 +43,7 @@ func Wrapper(err error) (string, error) {
 	if unwrapped != nil {
 		return strings.TrimRight(strings.TrimSuffix(err.Error(), unwrapped.Error()), ": "), unwrapped
 	}
+
 	return err.Error(), nil
 }
 
@@ -53,6 +55,7 @@ var StructureError = func(err error) []string {
 		str, err = Wrapper(err)
 		fullError = append(fullError, str)
 	}
+
 	return fullError
 }
 

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -438,6 +438,7 @@ func TestDebug_Signal(t *testing.T) {
 
 	if level != 0 || strs != nil {
 		t.Error("With loglevel=info, signal() should not have been called")
+
 		return
 	}
 
@@ -485,6 +486,7 @@ func TestDebugf_Signal(t *testing.T) {
 
 	if level != 0 || strs != nil {
 		t.Error("With loglevel=info, signal() should not have been called")
+
 		return
 	}
 

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -135,14 +135,16 @@ func TestError(t *testing.T) {
 
 	Error(errors.New(message))
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.ErrorLevel {
+	case testHook.LastEntry().Level != logrus.ErrorLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.ErrorLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
+
 }
 
 func TestError_Signal(t *testing.T) {
@@ -165,13 +167,15 @@ func TestError_Signal(t *testing.T) {
 
 	Error(errors.New(message))
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.ErrorLevel) {
+	case level != int(logrus.ErrorLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.ErrorLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
+
 }
 
 func TestErrorf(t *testing.T) {
@@ -187,14 +191,16 @@ func TestErrorf(t *testing.T) {
 
 	Errorf("This is an %s error: %w", "unexpected", errors.New("Where am I?"))
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.ErrorLevel {
+	case testHook.LastEntry().Level != logrus.ErrorLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.ErrorLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
+
 }
 
 func TestErrorf_Signal(t *testing.T) {
@@ -217,13 +223,15 @@ func TestErrorf_Signal(t *testing.T) {
 
 	Errorf("This is an %s error: %w", "unexpected", errors.New("Who are you?"))
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.ErrorLevel) {
+	case level != int(logrus.ErrorLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.ErrorLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
+
 }
 
 func TestWarning(t *testing.T) {
@@ -239,14 +247,16 @@ func TestWarning(t *testing.T) {
 
 	Warning(errors.New(message))
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.WarnLevel {
+	case testHook.LastEntry().Level != logrus.WarnLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.WarnLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
+
 }
 
 func TestWarning_Signal(t *testing.T) {
@@ -269,13 +279,15 @@ func TestWarning_Signal(t *testing.T) {
 
 	Warning(errors.New(message))
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.WarnLevel) {
+	case level != int(logrus.WarnLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.WarnLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
+
 }
 
 func TestWarningf(t *testing.T) {
@@ -291,12 +303,13 @@ func TestWarningf(t *testing.T) {
 
 	Warningf("%s the sun will shine: %w", "Tomorrow", errors.New("Remember sunscreen"))
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.WarnLevel {
+	case testHook.LastEntry().Level != logrus.WarnLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.WarnLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }
@@ -321,11 +334,12 @@ func TestWarningf_Signal(t *testing.T) {
 
 	Warningf("%s the sun will not shine: %w", "Tomorrow", errors.New("It is the end of days"))
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.WarnLevel) {
+	case level != int(logrus.WarnLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.WarnLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
 }
@@ -337,12 +351,13 @@ func TestInfo(t *testing.T) {
 
 	Info("I am ", "grand,", " and you?")
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.InfoLevel {
+	case testHook.LastEntry().Level != logrus.InfoLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.InfoLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }
@@ -359,11 +374,12 @@ func TestInfo_Signal(t *testing.T) {
 
 	Info("I am ", "grand,", " and you?")
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.InfoLevel) {
+	case level != int(logrus.InfoLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.InfoLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
 }
@@ -375,12 +391,13 @@ func TestInfof(t *testing.T) {
 
 	Infof("%d students barged in the %s", 100, "classroom")
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.InfoLevel {
+	case testHook.LastEntry().Level != logrus.InfoLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.InfoLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }
@@ -397,11 +414,12 @@ func TestInfof_Signal(t *testing.T) {
 
 	Infof("%d students barged in the %s", 99, "classroom")
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.InfoLevel) {
+	case level != int(logrus.InfoLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.InfoLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
 }
@@ -413,12 +431,13 @@ func TestDebug(t *testing.T) {
 
 	Debug("Why did a ", "thing happen? ", "I don't know")
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.DebugLevel {
+	case testHook.LastEntry().Level != logrus.DebugLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.DebugLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }
@@ -445,11 +464,12 @@ func TestDebug_Signal(t *testing.T) {
 	log.SetLevel(logrus.DebugLevel)
 	Debug("When did ", "this happen? ", "I don't know")
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.DebugLevel) {
+	case level != int(logrus.DebugLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.DebugLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
 }
@@ -461,12 +481,13 @@ func TestDebugf(t *testing.T) {
 
 	Debugf("%d ducks crossed the road. %s", 10, "And?")
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.DebugLevel {
+	case testHook.LastEntry().Level != logrus.DebugLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.DebugLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }
@@ -493,11 +514,12 @@ func TestDebugf_Signal(t *testing.T) {
 	log.SetLevel(logrus.DebugLevel)
 	Debugf("%d dogs crossed the road. %s", 8, "And?")
 
-	if len(testHook.Entries) != 0 {
+	switch {
+	case len(testHook.Entries) != 0:
 		t.Error("Logger with signal should not have logged to stdout")
-	} else if level != int(logrus.DebugLevel) {
+	case level != int(logrus.DebugLevel):
 		t.Errorf("Logger with signal logged at incorrect level. Expected=%d, received=%d", int(logrus.DebugLevel), level)
-	} else if !reflect.DeepEqual(strs, []string{message}) {
+	case !reflect.DeepEqual(strs, []string{message}):
 		t.Errorf("Logger with signal gave incorrect message\nExpected=%v\nReceived=%v", []string{message}, strs)
 	}
 }
@@ -512,12 +534,13 @@ func TestFatal(t *testing.T) {
 	message := "Too late. All 5 programs are dead"
 	Fatal("Too late. ", "All ", 5, " programs are dead")
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.FatalLevel {
+	case testHook.LastEntry().Level != logrus.FatalLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.FatalLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }
@@ -532,12 +555,13 @@ func TestFatalf(t *testing.T) {
 	message := "No! This cannot be happening! Football is cancelled"
 	Fatalf("No! This cannot be happening! %s is cancelled", "Football")
 
-	if len(testHook.Entries) != 1 {
+	switch {
+	case len(testHook.Entries) != 1:
 		t.Errorf("Logger did not make the correct amount of entries. Expected=1, received=%d", len(testHook.Entries))
-	} else if testHook.LastEntry().Level != logrus.FatalLevel {
+	case testHook.LastEntry().Level != logrus.FatalLevel:
 		t.Errorf("Logger logged at incorrect level. Expected=%s, received=%s",
 			logrus.FatalLevel.String(), testHook.LastEntry().Level.String())
-	} else if testHook.LastEntry().Message != message {
+	case testHook.LastEntry().Message != message:
 		t.Errorf("Logger displayed incorrect message\nExpected=%s\nReceived=%s", message, testHook.LastEntry().Message)
 	}
 }

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -157,8 +157,8 @@ func TestError_Signal(t *testing.T) {
 		return []string{err.Error()}
 	}
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -209,8 +209,8 @@ func TestErrorf_Signal(t *testing.T) {
 		return []string{err.Error()}
 	}
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -261,8 +261,8 @@ func TestWarning_Signal(t *testing.T) {
 		return []string{err.Error()}
 	}
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -313,8 +313,8 @@ func TestWarningf_Signal(t *testing.T) {
 		return []string{err.Error()}
 	}
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -351,8 +351,8 @@ func TestInfo_Signal(t *testing.T) {
 	defer testHook.Reset()
 	message := "I am grand, and you?"
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -389,8 +389,8 @@ func TestInfof_Signal(t *testing.T) {
 	defer testHook.Reset()
 	message := "99 students barged in the classroom"
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -427,8 +427,8 @@ func TestDebug_Signal(t *testing.T) {
 	defer testHook.Reset()
 	message := "When did this happen? I don't know"
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}
@@ -475,8 +475,8 @@ func TestDebugf_Signal(t *testing.T) {
 	defer testHook.Reset()
 	message := "8 dogs crossed the road. And?"
 
-	var level int = 0
-	var strs []string = nil
+	var level int
+	var strs []string
 	signal = func(i int, s []string) {
 		level, strs = i, s
 	}

--- a/internal/mountpoint/mountpoint.go
+++ b/internal/mountpoint/mountpoint.go
@@ -16,5 +16,6 @@ var DefaultMountPoint = func() (string, error) {
 	if err = CheckMountPoint(p); err != nil {
 		return "", fmt.Errorf("Cannot create Data Gateway in default directory: %w", err)
 	}
+
 	return p, nil
 }

--- a/internal/mountpoint/mountpoint_unix.go
+++ b/internal/mountpoint/mountpoint_unix.go
@@ -21,6 +21,7 @@ var CheckMountPoint = func(mount string) error {
 		if err = os.MkdirAll(mount, 0755); err != nil {
 			return fmt.Errorf("Could not create directory %s", mount)
 		}
+
 		return nil
 	} else if err != nil {
 		return err
@@ -45,9 +46,11 @@ var CheckMountPoint = func(mount string) error {
 		if err != nil {
 			return fmt.Errorf("Error occurred when trying to read from directory %s: %w", mount, err)
 		}
+
 		return fmt.Errorf("Mount point %s must be empty", mount)
 	}
 
 	logs.Debugf("Directory %s is a valid mount point", mount)
+
 	return nil
 }

--- a/internal/mountpoint/mountpoint_unix_test.go
+++ b/internal/mountpoint/mountpoint_unix_test.go
@@ -122,6 +122,7 @@ type Testfs struct {
 
 func (t *Testfs) Getattr(path string, stat *fuse.Stat_t, fh uint64) (errc int) {
 	stat.Mode = fuse.S_IFDIR | 0755
+
 	return 0
 }
 

--- a/internal/mountpoint/mountpoint_windows.go
+++ b/internal/mountpoint/mountpoint_windows.go
@@ -24,6 +24,6 @@ var CheckMountPoint = func(mount string) error {
 			return fmt.Errorf("Could not create a path to directory %s: %w", mount, err)
 		}
 	}
-	
+
 	return nil
 }

--- a/internal/mountpoint/mountpoint_windows.go
+++ b/internal/mountpoint/mountpoint_windows.go
@@ -24,5 +24,6 @@ var CheckMountPoint = func(mount string) error {
 			return fmt.Errorf("Could not create a path to directory %s: %w", mount, err)
 		}
 	}
+	
 	return nil
 }


### PR DESCRIPTION
Introduce more restrictive linting: with:

```
golangci-lint run -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107 --skip-files cmd/qt/moc.go,cmd/qt/main.go
```

- consistent variable names
- consistent use of replaceAll
- refactor ifElseChain & not required else branch
- unlambda: replace `func() time.Time
- fix underef: could simplify (*v).Decrypted to v.Decrypted
- fix assignop
- fix var-declaration
- continue & return require new line before
