### PR TITLE
Add hyphen to repository names in filesystem structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactor GUI to use Wails
+- Renamed:
+  - `SD Connect` to `SD-Connect` in the filesystem
+  - `SD Apply` to `SD-Apply` in the filesystem
 
 ### Added
 

--- a/frontend/src/components/Access.vue
+++ b/frontend/src/components/Access.vue
@@ -55,6 +55,7 @@ onMounted(() => {
 EventsOn('sendProjects', function(projects: filesystem.Project[]) {
     let tableData: CDataTableData[] = projects.map(project => {
         let item: CDataTableData = Object.fromEntries(Object.entries(project).map(([k, v]) => [k, {"value": v}]));
+        item['repository'].formattedValue = project.repository.replace("-", " ");
         item['progress'] = {"value": 0};
         return item;
     });

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -14,7 +14,8 @@ import (
 
 // This file contains structs and functions that are strictly for SD Connect
 
-const SDConnect string = "SD Connect"
+const SDConnect string = "SD-Connect"
+const SDConnectPrnt string = "SD Connect"
 
 // This exists for unit test mocking
 type connectable interface {
@@ -70,7 +71,7 @@ func (c *connecter) getProjects() ([]Metadata, error) {
 	headers := map[string]string{"X-Authorization": "Basic " + *c.token}
 	err := MakeRequest(*c.url+"/projects", nil, headers, nil, &projects)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve %s projects: %w", SDConnect, err)
+		return nil, fmt.Errorf("Failed to retrieve %s projects: %w", SDConnectPrnt, err)
 	}
 
 	return projects, nil
@@ -99,16 +100,16 @@ func (c *connecter) getSTokens(projects []Metadata) map[string]sToken {
 	for i := range projects {
 		projectToken, err := c.getToken(projects[i].Name)
 		if err != nil {
-			logs.Warningf("Failed to retrieve %s scoped token for %s: %w", SDConnect, projects[i].Name, err)
+			logs.Warningf("Failed to retrieve %s scoped token for %s: %w", SDConnectPrnt, projects[i].Name, err)
 
 			continue
 		}
 
-		logs.Debugf("Retrieved %s scoped token for %s", SDConnect, projects[i].Name)
+		logs.Debugf("Retrieved %s scoped token for %s", SDConnectPrnt, projects[i].Name)
 		newSTokens[projects[i].Name] = sToken{Token: projectToken.Token, ProjectID: projectToken.ProjectID}
 	}
 
-	logs.Infof("Fetching %s tokens finished", SDConnect)
+	logs.Infof("Fetching %s tokens finished", SDConnectPrnt)
 
 	return newSTokens
 }
@@ -124,7 +125,7 @@ func (c *sdConnectInfo) getEnvs() error {
 	}
 	c.url = strings.TrimRight(api, "/")
 	if err := testURL(c.url); err != nil {
-		return fmt.Errorf("Cannot connect to %s API: %w", SDConnect, err)
+		return fmt.Errorf("Cannot connect to %s API: %w", SDConnectPrnt, err)
 	}
 
 	return nil
@@ -153,9 +154,9 @@ func (c *sdConnectInfo) validateLogin(auth ...string) error {
 		}
 	} else if c.projects, err = c.getProjects(); err == nil {
 		if len(c.projects) == 0 {
-			return fmt.Errorf("No projects found for %s", SDConnect)
+			return fmt.Errorf("No projects found for %s", SDConnectPrnt)
 		}
-		logs.Infof("Retrieved %d %s project(s)", len(c.projects), SDConnect)
+		logs.Infof("Retrieved %d %s project(s)", len(c.projects), SDConnectPrnt)
 		c.sTokens = c.getSTokens(c.projects)
 
 		return nil
@@ -163,13 +164,13 @@ func (c *sdConnectInfo) validateLogin(auth ...string) error {
 
 	var re *RequestError
 	if errors.As(err, &re) && re.StatusCode == 401 {
-		return fmt.Errorf("%s login failed: %w", SDConnect, err)
+		return fmt.Errorf("%s login failed: %w", SDConnectPrnt, err)
 	}
 	if errors.As(err, &re) && re.StatusCode == 500 {
-		return fmt.Errorf("%s is not available, please contact CSC servicedesk: %w", SDConnect, err)
+		return fmt.Errorf("%s is not available, please contact CSC servicedesk: %w", SDConnectPrnt, err)
 	}
 
-	return fmt.Errorf("Error occurred for %s: %w", SDConnect, err)
+	return fmt.Errorf("Error occurred for %s: %w", SDConnectPrnt, err)
 }
 
 func (c *sdConnectInfo) levelCount() int {
@@ -209,7 +210,7 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 func (c *sdConnectInfo) tokenExpired(err error) bool {
 	var re *RequestError
 	if errors.As(err, &re) && re.StatusCode == 401 {
-		logs.Infof("%s tokens no longer valid. Fetching them again", SDConnect)
+		logs.Infof("%s tokens no longer valid. Fetching them again", SDConnectPrnt)
 		c.sTokens = c.getSTokens(c.projects)
 
 		return true
@@ -226,7 +227,7 @@ func (c *sdConnectInfo) updateAttributes(nodes []string, path string, attr any) 
 	size, ok := attr.(*int64)
 	if !ok {
 		return fmt.Errorf("%s updateAttributes() was called with incorrect attribute. Expected type *int64, received %v",
-			SDConnect, reflect.TypeOf(attr))
+			SDConnectPrnt, reflect.TypeOf(attr))
 	}
 
 	var headers SpecialHeaders

--- a/internal/api/sdsubmit.go
+++ b/internal/api/sdsubmit.go
@@ -15,7 +15,8 @@ import (
 // We name it SD Apply as that is where the datasets access is registered
 // However the datasets are mostly in SD Submit backend
 
-const SDSubmit string = "SD Apply"
+const SDSubmit string = "SD-Apply"
+const SDSubmitPrnt string = "SD Apply"
 
 // This exists for unit test mocking
 type submittable interface {
@@ -62,10 +63,10 @@ func (s *submitter) getDatasets(urlStr string) ([]string, error) {
 	var datasets []string
 	err := MakeRequest(urlStr+"/metadata/datasets", nil, nil, nil, &datasets)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve %s datasets from API %s: %w", SDSubmit, urlStr, err)
+		return nil, fmt.Errorf("Failed to retrieve %s datasets from API %s: %w", SDSubmitPrnt, urlStr, err)
 	}
 
-	logs.Infof("Retrieved %d %s dataset(s) from API %s", len(datasets), SDSubmit, urlStr)
+	logs.Infof("Retrieved %d %s dataset(s) from API %s", len(datasets), SDSubmitPrnt, urlStr)
 
 	return datasets, nil
 }
@@ -117,11 +118,11 @@ func (s *sdSubmitInfo) getEnvs() error {
 	s.urls = []string{}
 	for i, u := range strings.Split(urls, ",") {
 		if err = validURL(u); err != nil {
-			return fmt.Errorf("%s API not a valid URL: %w", SDSubmit, err)
+			return fmt.Errorf("%s API not a valid URL: %w", SDSubmitPrnt, err)
 		}
 		s.urls = append(s.urls, strings.TrimRight(u, "/"))
 		if err := testURL(s.urls[i]); err != nil {
-			return fmt.Errorf("Cannot connect to %s registered API: %w", SDSubmit, err)
+			return fmt.Errorf("Cannot connect to %s registered API: %w", SDSubmitPrnt, err)
 		}
 	}
 
@@ -137,14 +138,14 @@ func (s *sdSubmitInfo) validateLogin(auth ...string) error {
 		if err != nil {
 			var re *RequestError
 			if errors.As(err, &re) && re.StatusCode == 401 {
-				return fmt.Errorf("%s authorization failed: %w", SDSubmit, err)
+				return fmt.Errorf("%s authorization failed: %w", SDSubmitPrnt, err)
 			}
 
 			if errors.As(err, &re) && re.StatusCode == 500 {
-				logs.Warningf("Cannot connect to %s API %s: %w", SDSubmit, s.urls[i], err)
+				logs.Warningf("Cannot connect to %s API %s: %w", SDSubmitPrnt, s.urls[i], err)
 				count500++
 			} else {
-				logs.Warningf("Something went wrong when fetching %s datasets from API %s: %w", SDSubmit, s.urls[i], err)
+				logs.Warningf("Something went wrong when fetching %s datasets from API %s: %w", SDSubmitPrnt, s.urls[i], err)
 				count++
 			}
 		} else {
@@ -157,11 +158,11 @@ func (s *sdSubmitInfo) validateLogin(auth ...string) error {
 	if len(s.datasets) == 0 {
 		switch {
 		case count500 > 0:
-			return fmt.Errorf("%s is not available, please contact CSC servicedesk", SDSubmit)
+			return fmt.Errorf("%s is not available, please contact CSC servicedesk", SDSubmitPrnt)
 		case count > 0:
-			return fmt.Errorf("Error(s) occurred for %s", SDSubmit)
+			return fmt.Errorf("Error(s) occurred for %s", SDSubmitPrnt)
 		default:
-			return fmt.Errorf("No datasets found for %s", SDSubmit)
+			return fmt.Errorf("No datasets found for %s", SDSubmitPrnt)
 		}
 	}
 
@@ -203,7 +204,7 @@ func (s *sdSubmitInfo) updateAttributes(nodes []string, path string, attr any) e
 func (s *sdSubmitInfo) downloadData(nodes []string, buffer any, start, end int64) error {
 	idx, ok := s.datasets[nodes[0]]
 	if !ok {
-		return fmt.Errorf("Tried to request content of %s file %s with invalid dataset %s", SDSubmit, nodes[1], nodes[0])
+		return fmt.Errorf("Tried to request content of %s file %s with invalid dataset %s", SDSubmitPrnt, nodes[1], nodes[0])
 	}
 
 	// Query params

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -91,7 +91,7 @@ func InitializeFileSystem(send func(Project)) *Fuse {
 	fs.root.stat.Size = -1
 
 	for _, enabled := range api.GetEnabledRepositories() {
-		logs.Info("Beginning filling in ", enabled)
+		logs.Info("Beginning filling in ", strings.ReplaceAll(enabled, "-", " "))
 
 		// Create folders for each repository
 		md := api.Metadata{Name: enabled, Bytes: -1}


### PR DESCRIPTION
To make it easier for users to utilise the filesystem in code, the spaces in repository names are replaced with hyphens.