### PR TITLE
Do not allow 'Export not possible' to show for project managers

### DIFF
--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -161,7 +161,6 @@ func (a *App) Login(username, password string) (bool, error) {
 	}
 
 	logs.Info("Login successful")
-	wailsruntime.EventsEmit(a.ctx, "sdconnectAvailable")
 
 	isManager, err := airlock.IsProjectManager("")
 	switch {
@@ -178,6 +177,7 @@ func (a *App) Login(username, password string) (bool, error) {
 		}
 	}
 
+	wailsruntime.EventsEmit(a.ctx, "sdconnectAvailable")
 	return true, nil
 }
 

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -178,6 +178,7 @@ func (a *App) Login(username, password string) (bool, error) {
 	}
 
 	wailsruntime.EventsEmit(a.ctx, "sdconnectAvailable")
+
 	return true, nil
 }
 


### PR DESCRIPTION
There is a moment, during which the backend is checking the manager status, that the 'Export is not possible' page is visible for the manager. Keep page on login page before manager status is checked.