### PR TITLE
fix bumping versions 2.1.2 and 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.1.2] 2023-06-02
+## [v2.1.3] 2023-06-02
 
 - Prevent logs from freezing UI by adding them at discrete intervals.
+
+## [v2.1.2] 2023-05-15
+
+- Updated dependencies
 
 ## [v2.1.1] 2023-05-03
 

--- a/cmd/gui/wails.json
+++ b/cmd/gui/wails.json
@@ -11,7 +11,7 @@
   "info": {
     "companyName": "CSC",
     "productName": "Data Gateway",
-    "productVersion": "2.1.2",
+    "productVersion": "2.1.3",
     "copyright": "MIT"
   }
 }

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -10,7 +10,7 @@ or download the release:
 ```
 sudo mkdir -p /etc/sda-fuse
 cd /etc/sda-fuse/
-export version=v2.1.2
+export version=v2.1.3
 wget "https://github.com/CSCfi/sda-filesystem/releases/download/${version}/go-fuse-gui-golang1.20-linux-amd64.zip"
 ```
 
@@ -23,7 +23,6 @@ sudo ln -s /etc/sda-fuse/sda-fuse /usr/bin/sda-fuse
 sudo wget https://raw.githubusercontent.com/CSCfi/sda-filesystem/refactor/wails-gui/build/appicon.png --directory-prefix=/etc/sda-fuse
 sudo cat > /etc/skel/Desktop/filesystem.desktop << EOF
 [Desktop Entry]
-Version=2.1.2
 Type=Application
 Terminal=false
 Exec=/usr/bin/sda-fuse

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This fixes my mistake of releasing 2.1.2 without making changes to changelog and other places
Removed version from Desktop Entry for linux as that was never required.