### PR TITLE
Don't encrypt file twice but create a temporary encrypted file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.5] 2023-07-27
+
+### Changed
+- Fix checksum calculation for files that need to be encrypted before exporting
+
 ## [v2.1.4] 2023-07-04
 
 ### Changed

--- a/cmd/airlock/main.go
+++ b/cmd/airlock/main.go
@@ -95,15 +95,12 @@ func main() {
 
 	_ = api.BasicToken(username, password)
 
-	var encrypted bool
-	if encrypted, err = airlock.CheckEncryption(filename); err != nil {
+	encrypted, err := airlock.CheckEncryption(filename)
+	if err != nil {
 		logs.Fatalf("Failed to check if file is encrypted: %s", err.Error())
-	} else if !encrypted {
-		*originalFilename = filename
-		filename += ".c4gh"
 	}
 
-	err = airlock.Upload(*originalFilename, filename, container, *journalNumber, uint64(*segmentSizeMb), !encrypted)
+	err = airlock.Upload(filename, container, uint64(*segmentSizeMb), *journalNumber, *originalFilename, encrypted)
 	if err != nil {
 		logs.Fatal(err)
 	}

--- a/cmd/gui/wails.json
+++ b/cmd/gui/wails.json
@@ -11,7 +11,7 @@
   "info": {
     "companyName": "CSC",
     "productName": "Data Gateway",
-    "productVersion": "2.1.4",
+    "productVersion": "2.1.5",
     "copyright": "MIT"
   }
 }

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -10,7 +10,7 @@ or download the release:
 ```
 sudo mkdir -p /etc/sda-fuse
 cd /etc/sda-fuse/
-export version=v2.1.4
+export version=v2.1.5
 wget "https://github.com/CSCfi/sda-filesystem/releases/download/${version}/go-fuse-gui-golang1.20-linux-amd64.zip"
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/ExportPage.vue
+++ b/frontend/src/pages/ExportPage.vue
@@ -79,8 +79,6 @@ watch(() => bucketQuery.value, (query: string) => {
 function selectFile() {
     SelectFile().then((filename: string) => {
         CheckEncryption(filename, selectedBucket.value).then((checks: Array<boolean>) => {
-            console.log(checks)
-            console.log(typeof checks)
             selectedFile.value = filename
             encrypted.value = checks[0]
 

--- a/frontend/src/pages/ExportPage.vue
+++ b/frontend/src/pages/ExportPage.vue
@@ -44,8 +44,8 @@ const pageIdx = ref(0)
 const selectedBucket = ref("")
 const bucketQuery = ref("")
 
-const file = ref("")
-const fileEncrypted = ref("")
+const selectedFile = ref("")
+const encrypted = ref(false)
 const showModal = ref(false)
 const chooseToContinue = ref(false)
 
@@ -65,17 +65,6 @@ EventsOn('setBuckets', (buckets: string[]) => {
     filteredBucketItems.value = bucketItems.value;
 })
 
-EventsOn('setExportFilenames', (fileOrig: string, fileEnc: string) => { 
-    file.value = fileOrig;
-    fileEncrypted.value = fileEnc;
-    let exportRow: CDataTableData = {
-        'name': {'value': fileEnc.split('/').reverse()[0]}, 
-        'folder': {'value': selectedBucket.value}
-    };
-    exportData.value = [];
-    exportData.value.push(exportRow);
-})
-
 watch(() => bucketQuery.value, (query: string) => { 
     selectedBucket.value = query;
     filteredBucketItems.value = bucketItems.value.filter((item: CAutocompleteItem) => {
@@ -89,8 +78,20 @@ watch(() => bucketQuery.value, (query: string) => {
 
 function selectFile() {
     SelectFile().then((filename: string) => {
-        CheckEncryption(filename, selectedBucket.value).then((exists: boolean) => {
-            if (exists) {
+        CheckEncryption(filename, selectedBucket.value).then((checks: Array<boolean>) => {
+            console.log(checks)
+            console.log(typeof checks)
+            selectedFile.value = filename
+            encrypted.value = checks[0]
+
+            let exportRow: CDataTableData = {
+                'name': {'value': filename.split('/').reverse()[0] + (!checks[0] ? ".c4gh" : "")}, 
+                'folder': {'value': selectedBucket.value}
+            };
+            exportData.value = [];
+            exportData.value.push(exportRow);
+
+            if (checks[1]) { // If exists
                 showModal.value = true;
             } else {
                 chooseToContinue.value = true;
@@ -104,7 +105,7 @@ function selectFile() {
 }
 
 function exportFile() {
-    ExportFile(selectedBucket.value, file.value, fileEncrypted.value).then(() => {
+    ExportFile(selectedFile.value, selectedBucket.value, encrypted.value).then(() => {
         pageIdx.value = 4;
     }).catch(e => {
         pageIdx.value = 2;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -5,9 +5,9 @@ export function Authenticate(arg1:string):Promise<void>;
 
 export function ChangeMountPoint():Promise<string>;
 
-export function CheckEncryption(arg1:string,arg2:string):Promise<boolean>;
+export function CheckEncryption(arg1:string,arg2:string):Promise<any>;
 
-export function ExportFile(arg1:string,arg2:string,arg3:string):Promise<void>;
+export function ExportFile(arg1:string,arg2:string,arg3:boolean):Promise<void>;
 
 export function GetDefaultMountPoint():Promise<string>;
 

--- a/internal/airlock/airlock.go
+++ b/internal/airlock/airlock.go
@@ -98,7 +98,6 @@ var IsProjectManager = func(project string) (bool, error) {
 	}
 
 	return false, nil
-
 }
 
 // GetPublicKey retrieves the public key from the proxy URL and checks its validity
@@ -321,6 +320,7 @@ var getFileDetailsEncrypt = func(filename string) (encFile *os.File, checksum st
 	}
 	if int64(memLeft) < fileSize {
 		err = fmt.Errorf("Not enough space for airlock export operation, consider using a volume or splinting the file")
+
 		return
 	}
 

--- a/internal/airlock/airlock.go
+++ b/internal/airlock/airlock.go
@@ -36,13 +36,6 @@ type airlockInfo struct {
 	overridden bool
 }
 
-type readCloser struct {
-	io.Reader
-	io.Closer
-
-	errc chan error
-}
-
 var GetProjectName = func() string {
 	return ai.project
 }
@@ -152,32 +145,36 @@ func GetPublicKey() error {
 }
 
 // Upload uploads a file to SD Connect
-func Upload(originalFilename, filename, container, journalNumber string, segmentSizeMb uint64, encrypt bool) error {
+func Upload(filename, container string, segmentSizeMb uint64, journalNumber, originalFilename string, encrypted bool) error {
 	var err error
-	var encryptedFile io.ReadCloser
+	var encryptedFile *os.File
 	var encryptedChecksum string
 	var encryptedFileSize int64
-	var errc chan error
-	var printFilename = originalFilename
 
-	if encrypt {
-		var rc *readCloser
-		logs.Info("Encrypting file ", originalFilename)
-		rc, encryptedChecksum, encryptedFileSize, err = getFileDetailsEncrypt(originalFilename)
-		encryptedFile = rc
-		if rc != nil {
-			errc = rc.errc
+	defer func() {
+		if encryptedFile != nil {
+			encryptedFile.Close()
+			if !encrypted {
+				os.Remove(encryptedFile.Name())
+			}
 		}
+	}()
+
+	if !encrypted {
+		logs.Info("Encrypting file ", filename)
+		encryptedFile, encryptedChecksum, encryptedFileSize, err = getFileDetailsEncrypt(filename)
 	} else {
 		logs.Info("File ", filename, " is already encrypted. Skipping encryption.")
 		encryptedFile, encryptedChecksum, encryptedFileSize, err = getFileDetails(filename)
-		printFilename = filename
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to get details for file %s: %w", printFilename, err)
+		return fmt.Errorf("Failed to get details for file %s: %w", filename, err)
 	}
-	defer encryptedFile.Close()
+
+	if !encrypted {
+		filename += ".c4gh"
+	}
 
 	logs.Debugf("File size %v", encryptedFileSize)
 	segmentSize := segmentSizeMb * uint64(minimumSegmentSize)
@@ -187,7 +184,7 @@ func Upload(originalFilename, filename, container, journalNumber string, segment
 	segmentNro := uint64(math.Ceil(float64(encryptedFileSize) / float64(segmentSize)))
 
 	object, container := reorderNames(filename, container)
-	logs.Info("Uploading object " + object + " to container " + container)
+	logs.Info("Beginning to upload object " + object + " to container " + container)
 
 	query := map[string]string{
 		"filename":  object,
@@ -196,8 +193,10 @@ func Upload(originalFilename, filename, container, journalNumber string, segment
 	}
 
 	if originalFilename != "" {
-		rc, originalChecksum, originalFilesize, err := getFileDetails(originalFilename)
-		rc.Close()
+		file, originalChecksum, originalFilesize, err := getFileDetails(originalFilename)
+		if file != nil {
+			file.Close()
+		}
 		if err != nil {
 			return fmt.Errorf("Failed to get details for file %s: %w", originalFilename, err)
 		}
@@ -216,7 +215,7 @@ func Upload(originalFilename, filename, container, journalNumber string, segment
 	if segmentNro < 2 {
 		err = put("", 1, 1, encryptedFile, query)
 		if err != nil {
-			return fmt.Errorf("Uploading file failed: %w", err)
+			return fmt.Errorf("Uploading file %s failed: %w", filepath.Base(filename), err)
 		}
 	} else {
 		uploadDir := ".segments/" + object + "/"
@@ -236,26 +235,17 @@ func Upload(originalFilename, filename, container, journalNumber string, segment
 			err = put(container+"/"+uploadDir, int(i+1), int(segmentNro),
 				io.LimitReader(encryptedFile, thisSegmentSize), query)
 			if err != nil {
-				return fmt.Errorf("Uploading file failed: %w", err)
+				return fmt.Errorf("Uploading file %s failed: %w", filepath.Base(filename), err)
 			}
 
 		}
-		logs.Info("Uploading manifest file for object " + object + " to container " +
-			container)
+		logs.Info("Uploading manifest file")
 
 		var empty *os.File
 		err = put(container+"/"+uploadDir, -1, -1, empty, query)
 		if err != nil {
 			return fmt.Errorf("Uploading manifest file failed: %w", err)
 		}
-	}
-
-	if errc == nil {
-		return nil
-	}
-
-	if err = <-errc; err != nil {
-		return fmt.Errorf("Streaming file failed: %w", err)
 	}
 
 	return nil
@@ -294,13 +284,13 @@ var getFileDetails = func(filename string) (*os.File, string, int64, error) {
 	hash := md5.New() // #nosec
 	_, err = io.Copy(hash, file)
 	if err != nil {
-		return nil, "", 0, err
+		return file, "", 0, err
 	}
 	checksum := hex.EncodeToString(hash.Sum(nil))
 
 	// Need to move file pointer to the beginning so that its content can be read again
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return nil, "", 0, err
+		return file, "", 0, err
 	}
 
 	return file, checksum, fileSize, nil
@@ -313,58 +303,38 @@ var newCrypt4GHWriter = func(w io.Writer) (io.WriteCloser, error) {
 	return streaming.NewCrypt4GHWriterWithoutPrivateKey(w, pubkeyList, nil)
 }
 
-var encrypt = func(file *os.File, pw *io.PipeWriter, errc chan error) {
-	defer pw.Close()
-	c4ghWriter, err := newCrypt4GHWriter(pw)
-	if err != nil {
-		errc <- err
-
-		return
-	}
-	if _, err = io.Copy(c4ghWriter, file); err != nil {
-		errc <- err
-
-		return
-	}
-	errc <- c4ghWriter.Close()
-}
-
 // getFileDetailsEncrypt is similar to getFileDetails() except the file has to be encrypted before it is read
-var getFileDetailsEncrypt = func(filename string) (rc *readCloser, checksum string, bytes_written int64, err error) {
+var getFileDetailsEncrypt = func(filename string) (encFile *os.File, checksum string, bytes_written int64, err error) {
 	var file *os.File
 	if file, err = os.Open(filename); err != nil {
 		return
 	}
-	defer func() {
-		// If error occurs, close file
-		if rc == nil {
-			file.Close()
-		}
-	}()
+	defer file.Close()
 
-	// The file needs to be read twice. Once for determiming checksum, once for http request.
-	// Both times file needs to be encrypted
-	errc := make(chan error, 1)
-	pr, pw := io.Pipe()        // So that 'c4ghWriter' can pass its contents to an io.Reader
-	go encrypt(file, pw, errc) // Writing from file to 'c4ghWriter' will not happen until 'pr' is being read. Code will hang without goroutine.
+	encFile, err = os.CreateTemp("", "encrypted.*.c4gh")
+	if err != nil {
+		return
+	}
 
 	hash := md5.New() // #nosec
-	if bytes_written, err = io.Copy(hash, pr); err != nil {
+	mwr := io.MultiWriter(encFile, hash)
+
+	c4ghWriter, err := newCrypt4GHWriter(mwr)
+	if err != nil {
 		return
 	}
+	bytes_written, err = io.Copy(c4ghWriter, file)
+	if err != nil {
+		return
+	}
+	if err = c4ghWriter.Close(); err != nil {
+		return
+	}
+
 	checksum = hex.EncodeToString(hash.Sum(nil))
-	if _, err = file.Seek(0, io.SeekStart); err != nil {
+	if _, err = encFile.Seek(0, io.SeekStart); err != nil {
 		return
 	}
-	if err = <-errc; err != nil {
-		return
-	}
-
-	errc = make(chan error, 1) // This error will be checked at the end of Upload()
-	pr, pw = io.Pipe()
-	go encrypt(file, pw, errc)
-
-	rc = &readCloser{pr, file, errc}
 
 	return
 }

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -285,7 +285,7 @@ func (c *sdConnectInfo) downloadData(nodes []string, buffer any, start, end int6
 	return err
 }
 
-// calculateDecryptedSize calculates the decrypted size of an encrypted file size
+// calculateDecryptedSize calculates the decrypted size of an encrypted file
 var calculateDecryptedSize = func(fileSize, headerSize int64) int64 {
 	// Crypt4GH settings
 	var blockSize int64 = 65536

--- a/internal/mountpoint/mountpoint_unix.go
+++ b/internal/mountpoint/mountpoint_unix.go
@@ -65,3 +65,9 @@ func WaitForUpdateSignal(ch chan<- bool) {
 		ch <- true
 	}
 }
+
+func BytesAvailable(dir string) (uint64, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(dir, &stat)
+	return stat.Bavail * uint64(stat.Bsize), err
+}

--- a/internal/mountpoint/mountpoint_unix.go
+++ b/internal/mountpoint/mountpoint_unix.go
@@ -69,5 +69,6 @@ func WaitForUpdateSignal(ch chan<- bool) {
 func BytesAvailable(dir string) (uint64, error) {
 	var stat unix.Statfs_t
 	err := unix.Statfs(dir, &stat)
+
 	return stat.Bavail * uint64(stat.Bsize), err
 }


### PR DESCRIPTION
crypt4gh encryption does not produce the same output when performed twice on the same file. Thus, the checksum was incorrect. To fix this, the encrypted output is performed once and saved to a temporary file.
Also, the way variables `filename` and `originalFilename` are used was changed to more intuitive.