### PR TITLE
Remove spinner above toggle for SD Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+
+### Changed
+- Remove the spinner above the toggle for SD Connect when logging in
+
 ## [v2.1.6] 2023-08-04
 
 ### Fixed

--- a/frontend/src/components/RepositorySelect.vue
+++ b/frontend/src/components/RepositorySelect.vue
@@ -45,7 +45,7 @@ function success() {
                 :disabled="props.disabled"
                 @changeValue="selected = $event.target.value">
             </c-switch>
-            <c-loader :hide="!loading"></c-loader>
+            <c-loader :hide="!loading || useForm"></c-loader>
             <div class="repository-name">{{ props.repository.replace("-", " ") }}</div>
         </c-row>
         <div>


### PR DESCRIPTION
Fixes issue https://gitlab.ci.csc.fi/sds-dev/bugs/-/issues/46
Apparently the spinner was confusing for users.