### PR TITLE
Enable listing more than 10000 objects in bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Remove the spinner above the toggle for SD Connect when logging in
 
+### Added
+- Enable listing more than 10000 objects in bucket with `marker` query parameter
+
 ## [v2.1.6] 2023-08-04
 
 ### Fixed

--- a/cmd/fuse/main_test.go
+++ b/cmd/fuse/main_test.go
@@ -152,6 +152,9 @@ func TestAskForLogin(t *testing.T) {
 		},
 	}
 
+	os.Unsetenv("CSC_USERNAME")
+	os.Unsetenv("CSC_PASSWORD")
+
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
 			// Ignore prints to stdout

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -235,7 +235,7 @@ var MakeRequest = func(url string, query, headers map[string]string, body io.Rea
 	var request *http.Request
 
 	if body != nil {
-		if reflect.ValueOf(body) == reflect.Zero(reflect.TypeOf(body)) {
+		if reflect.ValueOf(body) == reflect.Zero(reflect.TypeOf(body)) { // manifest file in airlock
 			request, err = http.NewRequest("PUT", url, nil)
 		} else {
 			request, err = http.NewRequest("PUT", url, body)

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -182,7 +182,6 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 		return c.projects, nil
 	}
 
-	headers := map[string]string{}
 	path := c.url + "/project/" + url.PathEscape(nodes[0])
 	switch len(nodes) {
 	case 1:
@@ -193,11 +192,27 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 		return nil, nil
 	}
 
+	var err error
 	var meta []Metadata
-	err := c.makeRequest(path, nodes[0], nil, headers, &meta)
-	if c.tokenExpired(err) {
-		err = c.makeRequest(path, nodes[0], nil, headers, &meta)
+	headers := map[string]string{}
+	query := map[string]string{}
+
+	for {
+		var tmpmeta []Metadata
+		err = c.makeRequest(path, nodes[0], query, headers, &tmpmeta)
+		if c.tokenExpired(err) {
+			err = c.makeRequest(path, nodes[0], query, headers, &tmpmeta)
+		}
+
+		if len(tmpmeta) > 0 {
+			meta = append(meta, tmpmeta...)
+			query["marker"] = tmpmeta[len(tmpmeta)-1].Name
+		}
+		if len(tmpmeta) == 0 || len(nodes) == 1 {
+			break
+		}
 	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Failed to retrieve metadata for %s: %w", fsPath, err)
 	}

--- a/internal/api/sdconnect.go
+++ b/internal/api/sdconnect.go
@@ -192,16 +192,19 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 		return nil, nil
 	}
 
-	var err error
 	var meta []Metadata
 	headers := map[string]string{}
 	query := map[string]string{}
 
 	for {
 		var tmpmeta []Metadata
-		err = c.makeRequest(path, nodes[0], query, headers, &tmpmeta)
+		err := c.makeRequest(path, nodes[0], query, headers, &tmpmeta)
 		if c.tokenExpired(err) {
 			err = c.makeRequest(path, nodes[0], query, headers, &tmpmeta)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to retrieve metadata for %s: %w", fsPath, err)
 		}
 
 		if len(tmpmeta) > 0 {
@@ -211,10 +214,6 @@ func (c *sdConnectInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata,
 		if len(tmpmeta) == 0 || len(nodes) == 1 {
 			break
 		}
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve metadata for %s: %w", fsPath, err)
 	}
 
 	logs.Infof("Retrieved metadata for %s", fsPath)


### PR DESCRIPTION
A request can only return max 10000 objects per bucket
(Issue https://gitlab.ci.csc.fi/sds-dev/bugs/-/issues/32)

In this PR, a bucket's objects are requested multiple times until no more objects are returned. Importantly, a `marker` is included in the query, which is the name of the last object of the previous request. With `marker` the next request returns new objects and not the same ones over and over again. This fix in based on https://github.com/CSCfi/allas-cli-utils/blob/master/curl-utils/allas-list-objects.

This fix is dependent on https://gitlab.ci.csc.fi/sds-dev/sd-connect/sd-connect-api/-/merge_requests/56.