### PR TITLE
Make it possible to delete specific files from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Enable listing more than 10000 objects in bucket with `marker` query parameter
+- In CLI, the `clear <path>` command clears the cache for all files under `path`
 
 ## [v2.1.6] 2023-08-04
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Usage of ./go-fuse:
 ```
 Example run: `./go-fuse -mount=$HOME/ExampleMount` will create the FUSE layer in the directory `$HOME/ExampleMount` for both 'SD Connect' and 'SD Apply'.
 
+#### User input
+
+User can update the filesystem by inputting the command `update`. This requires that no files inside the filesystem are being used. Update also clears cache. As a result of this operation, new files may be added and some old ones removed.
+
+If the user wants to update particular SD Connect files inside the filesystem, the user can input command `clear <path>`. `<path>` is the path to the file/folder that the user wishes to update. `<path>` must at least contain a bucket, i.e. `SD-Connect/project/bucket` or `SD-Connect/project/bucket/file` would be acceptable paths, but not, e.g., `SD-Connect/project`. If the user gives a path to a folder, all files inside this folder are updated but no files are added or removed. This operation clears the cache for all the neccessary files so that the new content is read from the database and sizes of these files are updated in the filesystem.
+
 ### Airlock
 
 The CLI binary will require a username, a bucket and a filename. Password is either given as input or in an environmental variable.

--- a/cmd/fuse/main.go
+++ b/cmd/fuse/main.go
@@ -261,13 +261,14 @@ func main() {
 	go func() {
 		for {
 			input := <-wait
-			if strings.EqualFold(input[0], "update") {
+			switch strings.ToLower(input[0]) {
+			case "update":
 				if fs.FilesOpen() {
 					logs.Warningf("You have files in use which prevents updating Data Gateway")
 				} else {
 					fs.RefreshFilesystem(nil, nil)
 				}
-			} else if strings.EqualFold(input[0], "clear") {
+			case "clear":
 				if len(input) > 1 {
 					path := filepath.Clean(input[1])
 					if err := fs.ClearPath(path); err != nil {

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -230,7 +230,7 @@ func (a *App) LoadFuse() {
 			wailsruntime.EventsEmit(a.ctx, "fuseReady")
 		}()
 
-		var wait = make(chan bool)
+		var wait = make(chan []string)
 		go mountpoint.WaitForUpdateSignal(wait)
 		go func() {
 			for {
@@ -274,16 +274,13 @@ func (a *App) OpenFuse() {
 }
 
 func (a *App) RefreshFuse() error {
-	if a.fs.FilesOpen(a.mountpoint) {
+	if a.fs.FilesOpen() {
 		return fmt.Errorf("You have files in use which prevents updating Data Gateway")
 	}
-	logs.Info("Updating Data Gateway")
 	time.Sleep(200 * time.Millisecond)
 
 	a.ph.deleteProjects()
-	newFs := filesystem.InitializeFilesystem(a.ph.AddProject)
-	newFs.PopulateFilesystem(a.ph.trackContainers)
-	a.fs.RefreshFilesystem(newFs)
+	a.fs.RefreshFilesystem(a.ph.AddProject, a.ph.trackContainers)
 
 	buckets := a.fs.GetNodeChildren(api.SDConnect + "/" + airlock.GetProjectName())
 	if len(buckets) > 0 {

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -44,11 +44,11 @@ func (a *App) startup(ctx context.Context) {
 	filesystem.SetSignalBridge(a.Panic)
 }
 
-func (a *App) shutdown(ctx context.Context) {
+func (a *App) shutdown(_ context.Context) {
 	filesystem.UnmountFilesystem()
 }
 
-func (a *App) beforeClose(ctx context.Context) (prevent bool) {
+func (a *App) beforeClose(_ context.Context) (prevent bool) {
 	return a.preventQuit
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -374,7 +374,7 @@ var DownloadData = func(nodes []string, path string, start int64, end int64, max
 	endofst := end - chStart
 
 	// We create the cache key based on path and requested bytes
-	cacheKey := strings.Join(nodes, "_") + "_" + strconv.FormatInt(chStart, 10)
+	cacheKey := toCacheKey(nodes, chStart)
 	response, found := downloadCache.Get(cacheKey)
 
 	if !found {
@@ -403,6 +403,19 @@ var DownloadData = func(nodes []string, path string, start int64, end int64, max
 	return ret[ofst:endofst], nil
 }
 
+func toCacheKey(nodes []string, chunkIdx int64) string {
+	return strings.Join(nodes, "_") + "_" + strconv.FormatInt(chunkIdx, 10)
+}
+
 var ClearCache = func() {
 	downloadCache.Clear()
+}
+
+var DeleteFileFromCache = func(nodes []string, size int64) {
+	i := int64(0)
+	for i < size {
+		key := toCacheKey(nodes, i)
+		downloadCache.Del(key)
+		i += chunkSize
+	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -35,7 +35,7 @@ func (c *mockCache) Get(key string) (any, bool) {
 	return nil, false
 }
 
-func (c *mockCache) Set(key string, value any, cost int64, ttl time.Duration) bool {
+func (c *mockCache) Set(key string, value any, _ int64, _ time.Duration) bool {
 	c.key = key
 	c.data = value.([]byte)
 
@@ -52,7 +52,7 @@ type mockRepository struct {
 
 func (r *mockRepository) getEnvs() error { return r.envError }
 
-func (r *mockRepository) downloadData(nodes []string, buf any, start, end int64) error {
+func (r *mockRepository) downloadData(_ []string, buf any, _, _ int64) error {
 	_, _ = io.ReadFull(bytes.NewReader(r.mockDownloadDataBuf), buf.([]byte))
 
 	return r.mockDownloadDataError
@@ -350,7 +350,7 @@ type testTransport struct {
 	err error
 }
 
-func (t testTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+func (t testTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{}, t.err
 }
 

--- a/internal/api/sdsubmit.go
+++ b/internal/api/sdsubmit.go
@@ -129,7 +129,7 @@ func (s *sdSubmitInfo) getEnvs() error {
 	return nil
 }
 
-func (s *sdSubmitInfo) authenticate(auth ...string) error {
+func (s *sdSubmitInfo) authenticate(_ ...string) error {
 	s.datasets = make(map[string]int)
 	count, count500 := 0, 0
 
@@ -196,7 +196,7 @@ func (s *sdSubmitInfo) getNthLevel(fsPath string, nodes ...string) ([]Metadata, 
 }
 
 // Dummy function, not needed
-func (s *sdSubmitInfo) updateAttributes(nodes []string, path string, attr any) error {
+func (s *sdSubmitInfo) updateAttributes(_ []string, _ string, _ any) error {
 	return nil
 }
 

--- a/internal/api/sdsubmit_test.go
+++ b/internal/api/sdsubmit_test.go
@@ -31,7 +31,7 @@ func (s *mockSubmitter) getDatasets(urlStr string) ([]string, error) {
 
 }
 
-func (s *mockSubmitter) getFiles(fsPath, urlStr, dataset string) ([]Metadata, error) {
+func (s *mockSubmitter) getFiles(_, urlStr, _ string) ([]Metadata, error) {
 	if urlStr == s.mockURLOK {
 		return s.mockFiles, nil
 	}

--- a/internal/filesystem/enabled.go
+++ b/internal/filesystem/enabled.go
@@ -45,7 +45,7 @@ func (fs *Fuse) Open(path string, flags int) (errc int, fh uint64) {
 			return -fuse.EIO, ^uint64(0)
 
 		} else if n.node.stat.Size != newSize {
-			fs.updateNodeSizesAlongPath(path, n.node.stat.Size-newSize, fuse.Now())
+			fs.updateNodeSizesAlongPath(path, newSize-n.node.stat.Size, fuse.Now())
 		}
 		n.node.decryptionChecked = true
 	}

--- a/internal/filesystem/enabled.go
+++ b/internal/filesystem/enabled.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Open opens a file.
-func (fs *Fuse) Open(path string, flags int) (errc int, fh uint64) {
+func (fs *Fuse) Open(path string, _ int) (errc int, fh uint64) {
 	defer fs.synchronize()()
 	logs.Debug("Opening file ", filepath.FromSlash(path))
 
@@ -164,7 +164,7 @@ func (fs *Fuse) Read(path string, buff []byte, ofst int64, fh uint64) int {
 
 // Readdir reads the contents of a directory.
 func (fs *Fuse) Readdir(path string, fill func(name string, stat *fuse.Stat_t, ofst int64) bool,
-	ofst int64, fh uint64) (errc int) {
+	_ int64, fh uint64) (errc int) {
 	defer fs.synchronize()()
 	node := fs.getNode(path, fh).node
 	if node == nil {

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -174,7 +174,8 @@ func (fs *Fuse) RefreshFilesystem(initFunc func(Project), populateFunc func(stri
 func (fs *Fuse) FilesOpen() bool {
 	switch runtime.GOOS {
 	case "linux":
-		_, err := exec.Command("fuser", "-m", fs.mount).Output()
+		mount := fs.mount
+		_, err := exec.Command("fuser", "-m", mount).Output()
 		if err == nil {
 			return true
 		}

--- a/internal/mountpoint/mountpoint_unix.go
+++ b/internal/mountpoint/mountpoint_unix.go
@@ -57,12 +57,12 @@ var CheckMountPoint = func(mount string) error {
 	return nil
 }
 
-func WaitForUpdateSignal(ch chan<- bool) {
+func WaitForUpdateSignal(ch chan<- []string) {
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGUSR1)
 	for {
 		<-s
-		ch <- true
+		ch <- []string{"update"}
 	}
 }
 

--- a/internal/mountpoint/mountpoint_unix_test.go
+++ b/internal/mountpoint/mountpoint_unix_test.go
@@ -120,15 +120,15 @@ type Testfs struct {
 	fuse.FileSystemBase
 }
 
-func (t *Testfs) Getattr(path string, stat *fuse.Stat_t, fh uint64) (errc int) {
+func (t *Testfs) Getattr(_ string, stat *fuse.Stat_t, _ uint64) (errc int) {
 	stat.Mode = fuse.S_IFDIR | 0755
 
 	return 0
 }
 
-func (t *Testfs) Readdir(path string,
-	fill func(name string, stat *fuse.Stat_t, ofst int64) bool,
-	ofst int64, fh uint64) (errc int) {
+func (t *Testfs) Readdir(_ string,
+	_ func(_ string, _ *fuse.Stat_t, _ int64) bool,
+	_ int64, _ uint64) (errc int) {
 	return -fuse.EIO
 }
 

--- a/internal/mountpoint/mountpoint_windows.go
+++ b/internal/mountpoint/mountpoint_windows.go
@@ -31,7 +31,7 @@ var CheckMountPoint = func(mount string) error {
 	return nil
 }
 
-func WaitForUpdateSignal(ch chan<- bool) {
+func WaitForUpdateSignal(ch chan<- []string) {
 }
 
 func BytesAvailable(dir string) (freeBytes uint64, err error) {


### PR DESCRIPTION
...so that files can be updated if they are modified in SD Connect. File sizes are also updated. Works only in CLI. User has to input `clear <path>`, where `path` is the file/folder to be deleted. If the user gives a folder, all files in this folder are deleted. However, `path` must at least contain a bucket. 

I could have reused the `update` command for this but I thought it might lead to misunderstandings since this does not add or delete files from fuse.