### PR TITLE
ready state case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] 
+## [2.2.0] 
 
 ### Changed
 - Remove the spinner above the toggle for SD Connect when logging in
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Recover buttons after failed refresh in GUI
+- SD Submit changed code so that `ready` state is now lower case, make use of `strings.EqualFold` 
+for checking case insensitivity
 
 ## [v2.1.6] 2023-08-04
 

--- a/cmd/gui/wails.json
+++ b/cmd/gui/wails.json
@@ -11,7 +11,7 @@
   "info": {
     "companyName": "CSC",
     "productName": "Data Gateway",
-    "productVersion": "2.1.6",
+    "productVersion": "2.2.0",
     "copyright": "MIT"
   }
 }

--- a/docs/SD-Submit-API.md
+++ b/docs/SD-Submit-API.md
@@ -72,7 +72,7 @@ GET /metadata/datasets/repository.org/dataset/files?scheme=https
         "decryptedFileSize": 32,
         "decryptedFileChecksum": "hash",
         "decryptedFileChecksumType": "SHA256",
-        "fileStatus": "READY"
+        "fileStatus": "ready"
     },
 ]
 ```

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -10,7 +10,7 @@ or download the release:
 ```
 sudo mkdir -p /etc/sda-fuse
 cd /etc/sda-fuse/
-export version=v2.1.6
+export version=v2.2.0
 wget "https://github.com/CSCfi/sda-filesystem/releases/download/${version}/go-fuse-gui-golang1.20-linux-amd64.zip"
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.6",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/internal/api/sdsubmit.go
+++ b/internal/api/sdsubmit.go
@@ -90,7 +90,7 @@ func (s *submitter) getFiles(fsPath, urlStr, dataset string) ([]Metadata, error)
 
 	var metadata []Metadata
 	for i := range files {
-		if files[i].FileStatus == "READY" {
+		if strings.EqualFold(files[i].FileStatus, "ready") {
 			md := Metadata{Name: files[i].DisplayFileName, Bytes: files[i].DecryptedFileSize}
 			metadata = append(metadata, md)
 

--- a/internal/api/sdsubmit_test.go
+++ b/internal/api/sdsubmit_test.go
@@ -166,7 +166,7 @@ func Test_SDSubmit_GetFiles_Split_Pass(t *testing.T) {
 			FileSize:              20,
 			DecryptedFileSize:     20,
 			DecryptedFileChecksum: "if6ox",
-			FileStatus:            "READY",
+			FileStatus:            "ready",
 		},
 	}
 	testFileJSON, _ := json.Marshal(testFile)


### PR DESCRIPTION
SD Submit changed code so that `ready` state is now lower case, make use of `strings.EqualFold`  for checking case insensitive (see https://pkg.go.dev/strings#EqualFold)