### PR TITLE
Fuser in all OSs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1]
+
+### Changed
+- Now macOS uses `fuser` to check if files are open, and Windows uses handle.exe.
+
 ## [2.2.0] 
 
 ### Changed

--- a/cmd/gui/wails.json
+++ b/cmd/gui/wails.json
@@ -11,7 +11,7 @@
   "info": {
     "companyName": "CSC",
     "productName": "Data Gateway",
-    "productVersion": "2.2.0",
+    "productVersion": "2.2.1",
     "copyright": "MIT"
   }
 }

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -10,7 +10,7 @@ or download the release:
 ```
 sudo mkdir -p /etc/sda-fuse
 cd /etc/sda-fuse/
-export version=v2.2.0
+export version=v2.2.1
 wget "https://github.com/CSCfi/sda-filesystem/releases/download/${version}/go-fuse-gui-golang1.20-linux-amd64.zip"
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -187,6 +187,16 @@ func (fs *Fuse) FilesOpen() bool {
 		}
 
 		return len(output) > 0
+	case "windows":
+		volume, _ := os.Readlink(fs.mount)
+		output, err := exec.Command("handle.exe", "-a", "-nobanner", volume).Output()
+		if err != nil {
+			logs.Errorf("Update halted, could not determine if files are open: %w", err)
+
+			return true
+		}
+
+		return strings.Contains(string(output), volume)
 	default:
 		for _, n := range fs.openmap {
 			if n.node.stat.Mode&fuse.S_IFMT == fuse.S_IFREG {

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -894,6 +894,7 @@ func TestGetNodeChildren(t *testing.T) {
 	}{
 		{"Rep1/child_1", []string{"dir+", "kansio"}},
 		{"Rep1/child_2", []string{"+folder", "dir"}},
+		{"Rep1/child_4", nil},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
When updating the filesystem, Linux requires `fuser` to check if any files are in use. For macOS and Windows, the checks were not as strict, so in this PR, macOS and Windows also use `fuser` (or something equivalent) to check if files are open.

For Windows there is no `fuser` command, so the same behaviour is achieved with [handle.exe](https://learn.microsoft.com/en-us/sysinternals/downloads/handle). Install it, and add the folder it is in to PATH so that go-fuse can find it.

I knew that Windows required to ^C:s to end the program. While testing the update functionality on Windows, I noticed that after the first ^C, the old user inputs were inputted to Data Gateway again, updating the filesystem when I was trying to exit. So I was hoping that the shutdown function in main.go could be removed for Windows, since cgofuse seems to not be using it as well https://github.com/winfsp/cgofuse/blob/f87f5db493b56c5f4ebe482a1b7d02c7e5d572fa/fuse/host.go#L714C2-L728C3.